### PR TITLE
ci: add crate QA and trusted publishing

### DIFF
--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -42,6 +42,8 @@ jobs:
             --profile minimal \
             --component clippy \
             --component rustfmt
+          rustup default "$RUSTUP_TOOLCHAIN"
+          rustc --version
 
       - name: Read crate version
         id: crate

--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -1,0 +1,106 @@
+name: Publish s3-unspool
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: publish-s3-unspool
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      RUSTUP_TOOLCHAIN: "1.95.0"
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - name: Require main branch
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "This workflow must be dispatched from main; got $GITHUB_REF" >&2
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" \
+            --profile minimal \
+            --component clippy \
+            --component rustfmt
+
+      - name: Read crate version
+        id: crate
+        run: |
+          set -euo pipefail
+          version="$(python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          manifest = pathlib.Path("crates/s3-unspool/Cargo.toml")
+          data = tomllib.loads(manifest.read_text())
+          print(data["package"]["version"])
+          PY
+          )"
+          tag="v${version}"
+          {
+            echo "version=${version}"
+            echo "tag=${tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reject existing release tag
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          if git rev-parse -q --verify "refs/tags/${{ steps.crate.outputs.tag }}" >/dev/null; then
+            echo "Tag ${{ steps.crate.outputs.tag }} already exists" >&2
+            exit 1
+          fi
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run crate tests
+        run: cargo test -p s3-unspool
+
+      - name: Run clippy
+        run: cargo clippy -p s3-unspool --all-targets -- -D warnings
+
+      - name: Build crate documentation
+        run: cargo doc -p s3-unspool --no-deps
+
+      - name: Verify crate package
+        run: cargo publish -p s3-unspool --dry-run
+
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p s3-unspool
+
+      - name: Tag published commit
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.crate.outputs.tag }}" \
+            -m "Release s3-unspool ${{ steps.crate.outputs.version }}" \
+            "$GITHUB_SHA"
+          git push origin "refs/tags/${{ steps.crate.outputs.tag }}"

--- a/.github/workflows/s3-unspool-ci.yml
+++ b/.github/workflows/s3-unspool-ci.yml
@@ -1,0 +1,54 @@
+name: s3-unspool CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/publish-s3-unspool.yml"
+      - ".github/workflows/s3-unspool-ci.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/s3-unspool/**"
+
+permissions: {}
+
+concurrency:
+  group: s3-unspool-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qa:
+    name: QA
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RUSTUP_TOOLCHAIN: "1.95.0"
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" \
+            --profile minimal \
+            --component clippy \
+            --component rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run crate tests
+        run: cargo test -p s3-unspool
+
+      - name: Run clippy
+        run: cargo clippy -p s3-unspool --all-targets -- -D warnings
+
+      - name: Build crate documentation
+        run: cargo doc -p s3-unspool --no-deps
+
+      - name: Verify crate package
+        run: cargo package -p s3-unspool

--- a/.github/workflows/s3-unspool-ci.yml
+++ b/.github/workflows/s3-unspool-ci.yml
@@ -37,6 +37,8 @@ jobs:
             --profile minimal \
             --component clippy \
             --component rustfmt
+          rustup default "$RUSTUP_TOOLCHAIN"
+          rustc --version
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3-unspool"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3-unspool"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/README.md
+++ b/README.md
@@ -550,6 +550,14 @@ Consumers opt into a pre-release explicitly:
 cargo add s3-unspool@0.1.0-alpha.1
 ```
 
+Releases are published by the manual `Publish s3-unspool` GitHub Actions
+workflow. The workflow reads the version from `crates/s3-unspool/Cargo.toml`,
+publishes with crates.io Trusted Publishing, and creates the matching
+`v<version>` git tag only after `cargo publish` succeeds. Configure the
+`s3-unspool` crate on crates.io to trust this repository's
+`publish-s3-unspool.yml` workflow and the `release` GitHub environment before
+running it.
+
 ## Assumptions and Limits
 
 - The crate is built for Rust 1.95 and edition 2024.

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ identifiers such as `0.1.0-alpha.1`, `0.1.0-beta.1`, or `0.1.0-rc.1`.
 Consumers opt into a pre-release explicitly:
 
 ```sh
-cargo add s3-unspool@0.1.0-alpha.1
+cargo add s3-unspool@0.1.0-beta.2
 ```
 
 Releases are published by the manual `Publish s3-unspool` GitHub Actions

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -9,8 +9,8 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 documentation = "https://docs.rs/s3-unspool"
-keywords = ["aws", "s3", "zip", "lambda", "deployment"]
-categories = ["filesystem"]
+keywords = ["aws", "s3", "zip", "archive", "deployment"]
+categories = ["compression", "filesystem"]
 
 [dependencies]
 async-compression.workspace = true


### PR DESCRIPTION
## Summary
- add PR QA for the published s3-unspool crate: fmt, tests, clippy, docs, and cargo package
- add a manual trusted-publishing workflow for crates.io that reads the crate version from Cargo.toml
- prepare the next beta crate metadata as `0.1.0-beta.2`
- tag the repository as v<version> only after cargo publish succeeds

## Crate metadata
- publishable crate: `s3-unspool`
- unpublished workspace tools: `s3-unspool-cli` and `s3-unspool-lambda` both use `publish = false`
- author: `Alessandro Bologna <alessandro.bologna@gmail.com>`
- repository: `https://github.com/alessandrobologna/s3-unspool`
- keywords: `aws`, `s3`, `zip`, `archive`, `deployment`
- categories: `compression`, `filesystem`

## Security / workflow notes
- CI runs on pull_request with read-only repository permissions and no secrets
- publish is workflow_dispatch only, requires main, uses the release environment, and grants only contents:write plus id-token:write
- crates.io publishing uses rust-lang/crates-io-auth-action via OIDC; no CARGO_REGISTRY_TOKEN secret is supported
- third-party actions are pinned to immutable commit SHAs
- workflows select the installed Rust 1.95.0 toolchain before running Cargo commands

## Validation
- ruby YAML parse for both workflows
- actionlint .github/workflows/*.yml
- bash -n and shellcheck -s bash on extracted run blocks
- git diff --check
- RUSTUP_TOOLCHAIN=1.95.0 cargo fmt --all -- --check
- RUSTUP_TOOLCHAIN=1.95.0 cargo test -p s3-unspool
- RUSTUP_TOOLCHAIN=1.95.0 cargo clippy -p s3-unspool --all-targets -- -D warnings
- RUSTUP_TOOLCHAIN=1.95.0 RUSTDOCFLAGS="-D warnings" cargo doc -p s3-unspool --no-deps
- RUSTUP_TOOLCHAIN=1.95.0 cargo package -p s3-unspool
- RUSTUP_TOOLCHAIN=1.95.0 cargo publish -p s3-unspool --dry-run
