### PR TITLE
cli: add zip and unzip endpoint matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/alessandrobologna/s3-unspool"
 
 [workspace.dependencies]
 async-compression = { version = "0.4.42", default-features = false, features = ["tokio", "deflate"] }
-async_zip = { version = "0.0.18", features = ["tokio", "deflate"] }
+async_zip = { version = "0.0.18", features = ["tokio", "tokio-fs", "deflate"] }
 aws-config = "1.8.16"
 aws-sdk-s3 = { version = "1.131.0", default-features = false, features = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 aws-smithy-types = { version = "1.4.7", features = ["http-body-1-x"] }

--- a/README.md
+++ b/README.md
@@ -19,19 +19,20 @@ lists the destination prefix once, skips unchanged files when a catalog is
 available, and writes missing or changed files with conditional `PutObject`
 requests.
 
-The crate also includes an upload helper that streams a local directory into a
-cataloged ZIP object in S3. ZIPs produced by that helper can be extracted later
-without decompressing unchanged entries.
+The crate also includes zip helpers that stream either a local directory or an
+existing S3 prefix into a cataloged local or S3 ZIP. ZIPs produced by those
+helpers can be extracted later without decompressing unchanged entries.
 
 ## At a Glance
 
 | Capability | What happens |
 | --- | --- |
-| Full extract | Stream a ZIP object from S3 into an S3 prefix without local archive storage. |
+| Full unzip | Stream a ZIP from local disk or S3 into a local directory or S3 prefix. |
 | Incremental extract | Skip unchanged files before decompression when the ZIP contains the embedded catalog. |
 | Safe overwrite | Use `If-None-Match` for new keys and `If-Match` for changed keys. |
 | Destination scan | Use one `ListObjectsV2` pass; no per-object destination `HeadObject` calls. |
-| Upload helper | Stream a local directory into a cataloged ZIP object with multipart upload. |
+| Zip helpers | Stream a local directory or existing S3 prefix into a cataloged local or S3 ZIP. |
+| Directory markers | Preserve ZIP directory entries and zero-byte S3 folder marker objects for round trips. |
 | Large archive support | Plan source byte ranges and keep only a bounded source block window in memory. |
 
 Use `s3-unspool` when you need to deploy or synchronize many files from a ZIP
@@ -96,8 +97,8 @@ artifacts.
 ## Quick Start
 
 Create an AWS S3 client with the normal AWS SDK configuration. The two core
-library operations are extracting an existing S3 ZIP into an S3 prefix and
-uploading a local directory as a cataloged ZIP for fast future extracts.
+library operations are unzipping an existing ZIP into an S3 prefix and zipping a
+local directory or S3 prefix as a cataloged ZIP for fast future extracts.
 
 ### Extract an S3 ZIP to a Destination Prefix
 
@@ -137,7 +138,8 @@ same ZIP object.
 
 Use `upload_directory_zip_to_s3` when you want `s3-unspool` to create the source
 ZIP. Uploads stream the ZIP into S3 with multipart upload and include the
-embedded catalog by default.
+embedded catalog by default. Empty local directories are written as ZIP
+directory entries so a later extract can recreate them as S3 marker objects.
 
 ```rust
 use aws_config::BehaviorVersion;
@@ -166,6 +168,42 @@ async fn main() -> s3_unspool::Result<()> {
 
 `UploadOptions::include_catalog` is `true` by default. Set it to `false` only
 when you need a plain ZIP without the update-skip catalog.
+
+### Upload an S3 Prefix as a Cataloged ZIP
+
+Use `zip_s3_prefix_to_s3` when the source files already live in S3 and you want
+to snapshot them into a ZIP object without downloading them locally. Source
+objects are streamed with `GetObject`, and the destination ZIP is written with
+multipart upload.
+
+```rust
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::Client;
+use s3_unspool::{S3Object, S3Prefix, S3PrefixUploadOptions, zip_s3_prefix_to_s3};
+
+#[tokio::main]
+async fn main() -> s3_unspool::Result<()> {
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let client = Client::new(&config);
+
+    let upload = S3PrefixUploadOptions::new(
+        S3Prefix::parse("s3://my-bucket/www/")?,
+        S3Object::parse("s3://my-bucket/releases/site.zip")?,
+    );
+    let report = zip_s3_prefix_to_s3(&client, upload).await?;
+
+    println!(
+        "uploaded {} files and {} directories into {} bytes",
+        report.files, report.directories, report.zip_bytes
+    );
+
+    Ok(())
+}
+```
+
+The destination ZIP object cannot be inside the listed source prefix. That
+prevents an existing archive from being accidentally included in the new
+archive.
 
 ### Source and Destination Clients
 
@@ -236,6 +274,21 @@ Library callers that prefer all-or-nothing behavior can set
 observed conditional conflict returns an error and the run stops before
 deleting extra destination objects.
 
+### Directory Marker Policy
+
+ZIP directory entries and S3 folder marker objects are preserved explicitly:
+
+- A ZIP directory entry such as `assets/empty/` extracts to a zero-byte S3
+  object with the same trailing-slash key.
+- An empty local directory uploads as a ZIP directory entry.
+- A zero-byte S3 object whose key ends in `/` uploads as a ZIP directory entry.
+- A zero-byte S3 object whose key does not end in `/` uploads as a regular file
+  entry.
+- A nonzero S3 object whose key ends in `/` is rejected as ambiguous.
+
+This policy makes empty directories round-trip through ZIP -> S3 -> ZIP instead
+of disappearing silently.
+
 ## Required S3 Permissions
 
 Extraction needs:
@@ -247,6 +300,14 @@ Extraction needs:
 | Destination prefix | `s3:PutObject` | Write missing and changed objects. |
 | Destination prefix | `s3:GetObject` | Authorize conditional overwrites with `If-Match`. |
 | Destination prefix | `s3:DeleteObject` | Only needed when `delete_extra` is enabled. |
+
+S3-prefix upload needs:
+
+| Scope | Permission | Why |
+| --- | --- | --- |
+| Source bucket | `s3:ListBucket` | List source keys, sizes, and ETags. |
+| Source prefix | `s3:GetObject` | Stream each source object into the ZIP. |
+| Destination ZIP object | `s3:PutObject`, `s3:AbortMultipartUpload` | Write the generated ZIP with multipart upload and clean up failed uploads. |
 
 The destination `s3:GetObject` permission is required even though
 `s3-unspool` does not issue per-file destination `HeadObject` requests or read
@@ -276,8 +337,8 @@ and upload sources cannot contain a file at that path.
 
 ## Command-Line Testing
 
-The repository includes a CLI for trying the same upload and extract flows from
-a terminal. Build it from a checkout:
+The repository includes a CLI for trying the same zip and unzip flows from a
+terminal. Build it from a checkout:
 
 ```sh
 cargo build --release -p s3-unspool-cli --bin s3-unspool
@@ -287,21 +348,34 @@ During development, commands can be run through Cargo:
 
 ```sh
 cargo run -p s3-unspool-cli -- \
-  upload ./site s3://my-bucket/releases/site.zip
+  zip ./site s3://my-bucket/releases/site.zip
 
 cargo run -p s3-unspool-cli -- \
-  extract s3://my-bucket/releases/site.zip s3://my-bucket/www/
+  unzip s3://my-bucket/releases/site.zip s3://my-bucket/www/
 ```
 
 The built binary is `./target/release/s3-unspool`:
 
 ```sh
-./target/release/s3-unspool extract \
+./target/release/s3-unspool unzip \
   s3://my-bucket/releases/site.zip \
   s3://my-bucket/www/
 ```
 
-Useful extract options:
+Supported endpoint combinations:
+
+```sh
+s3-unspool zip   ./site                  ./site.zip
+s3-unspool zip   ./site                  s3://my-bucket/site.zip
+s3-unspool zip   s3://my-bucket/www/     ./site.zip
+s3-unspool zip   s3://my-bucket/www/     s3://my-bucket/site.zip
+s3-unspool unzip ./site.zip              ./site
+s3-unspool unzip ./site.zip              s3://my-bucket/www/
+s3-unspool unzip s3://my-bucket/site.zip ./site
+s3-unspool unzip s3://my-bucket/site.zip s3://my-bucket/www/
+```
+
+Useful unzip options:
 
 - `--delete-extra`: delete destination objects under the prefix that are not in
   the ZIP.
@@ -309,8 +383,9 @@ Useful extract options:
   default is `64`.
 - `--report`: add a formatted operation report to the CLI transcript.
 - `--report=PATH`: write the JSON operation report to a file.
-- `--diagnostics`: add source scheduler, ranged `GetObject`, block cache, and
-  destination `PutObject` retry counters to the JSON report.
+- `--diagnostics`: for `s3://` ZIP sources, add source scheduler, ranged
+  `GetObject`, block cache, and, when unzipping to S3, destination `PutObject`
+  retry counters to the JSON report.
 - `--ignore-catalog`: ignore `.s3-unspool/catalog.v1.json` and compare existing
   destination objects by extracting and hashing each ZIP entry.
 
@@ -321,11 +396,11 @@ Global CLI options:
 
 ## CLI Output and Reports
 
-Interactive upload and extract commands show a single-line spinner with elapsed
+Interactive zip and unzip commands show a single-line spinner with elapsed
 time and progress where available:
 
 ```text
-• Uploading 00:03 [█████▍            ] 30% 18 MiB/512 MiB file 42/1000
+• Zipping 00:03 [█████▍            ] 30% 18 MiB/512 MiB file 42/1000
 ```
 
 The spinner is written to stderr, clears itself before the final summary, and is
@@ -334,7 +409,7 @@ disabled by `--quiet` or non-interactive output.
 Use bare `--report` to expand the final human-readable transcript:
 
 ```sh
-s3-unspool extract \
+s3-unspool unzip \
   --diagnostics \
   --report \
   s3://my-bucket/releases/site.zip \
@@ -344,25 +419,26 @@ s3-unspool extract \
 Use `--report=PATH` when you want JSON for automation:
 
 ```sh
-s3-unspool extract \
+s3-unspool unzip \
   --report=report.json \
   s3://my-bucket/releases/site.zip \
   s3://my-bucket/www/
 ```
 
-Formatted upload reports contain the source directory, destination ZIP object,
-file count, uncompressed bytes, uploaded ZIP bytes, wall time, and upload speed
+Formatted zip reports contain the source tree, destination ZIP, file and
+directory counts, uncompressed bytes, ZIP bytes, wall time, and zip speed
 in MiB/s.
 
-Extract reports contain:
+Unzip reports contain:
 
 - `summary`: totals for uploaded, skipped, conflicted, deleted, and errored
   objects.
 - `operations`: one record per relevant object.
-- `diagnostics`: optional source scheduler, block cache, and failed/retried
-  `PutObject` counters when diagnostics are enabled.
+- `diagnostics`: optional source scheduler and block cache counters when
+  diagnostics are enabled for `s3://` ZIP sources, plus failed/retried
+  `PutObject` counters when the destination is S3.
 
-Example extract summary:
+Example unzip summary:
 
 ```json
 {
@@ -517,14 +593,14 @@ scripts/mutate-fixture.py ./tmp/fixture ./tmp/fixture-10pct \
   --clean
 ```
 
-Upload and extract the fixtures:
+Zip and unzip the fixtures:
 
 ```sh
-s3-unspool upload ./tmp/fixture s3://my-bucket/fixtures/fixture.zip
-s3-unspool extract s3://my-bucket/fixtures/fixture.zip s3://my-bucket/fixture-out/
+s3-unspool zip ./tmp/fixture s3://my-bucket/fixtures/fixture.zip
+s3-unspool unzip s3://my-bucket/fixtures/fixture.zip s3://my-bucket/fixture-out/
 
-s3-unspool upload ./tmp/fixture-10pct s3://my-bucket/fixtures/fixture-10pct.zip
-s3-unspool extract s3://my-bucket/fixtures/fixture-10pct.zip s3://my-bucket/fixture-out/
+s3-unspool zip ./tmp/fixture-10pct s3://my-bucket/fixtures/fixture-10pct.zip
+s3-unspool unzip s3://my-bucket/fixtures/fixture-10pct.zip s3://my-bucket/fixture-out/
 ```
 
 Use these scripts to compare full deploys, no-op deploys, and update deploys
@@ -565,14 +641,17 @@ running it.
 
 - The crate is built for Rust 1.95 and edition 2024.
 - ZIP extraction supports Stored and Deflate entries.
-- Upload sources must be local directories.
-- Upload includes regular files recursively.
+- Local zip sources must be local directories and include regular files plus
+  empty directories recursively.
+- S3-prefix zip sources include regular objects and zero-byte trailing-slash
+  directory marker objects recursively.
 - Symbolic links and other special files are rejected.
-- Upload paths must be UTF-8 and cannot contain backslashes.
+- Zip source paths must be UTF-8 and cannot contain backslashes.
 - ZIP entry paths must be relative UTF-8 paths with no absolute roots, `..`,
   empty components, Windows drive prefixes, or backslashes.
-- Upload sources cannot contain `.s3-unspool/catalog.v1.json`.
-- Source ZIP uploads use S3 multipart upload so the archive can be streamed once
+- Zip sources cannot contain `.s3-unspool/catalog.v1.json`.
+- S3-prefix zip rejects nonzero objects whose keys end in `/`.
+- S3 ZIP destinations use S3 multipart upload so the archive can be streamed once
   without precomputing its final compressed size.
 - Destination objects are assumed to be written by this tool or by equivalent
   single-part `PutObject` writes.

--- a/crates/s3-unspool-cli/src/main.rs
+++ b/crates/s3-unspool-cli/src/main.rs
@@ -10,9 +10,13 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
 use s3_unspool::{
-    ObjectReport, OperationStatus, PutDiagnostics, S3Object, S3Prefix, SyncDiagnostics,
-    SyncOptions, SyncReport, UploadOptions, UploadProgress, UploadProgressHandler, UploadReport,
-    sync_zip_to_s3, upload_directory_zip_to_s3,
+    LocalUnzipOptions, LocalUnzipReport, LocalZipOptions, LocalZipReport, LocalZipSyncOptions,
+    LocalZipToS3Report, ObjectReport, OperationStatus, PutDiagnostics, S3Object, S3Prefix,
+    S3PrefixLocalZipOptions, S3PrefixUploadOptions, S3PrefixUploadReport, S3ZipLocalUnzipOptions,
+    SyncDiagnostics, SyncOptions, SyncReport, SyncSummary, UploadOptions, UploadProgress,
+    UploadProgressHandler, UploadReport, sync_zip_to_s3, unzip_file_to_local, unzip_file_to_s3,
+    unzip_s3_zip_to_local, upload_directory_zip_to_s3, zip_directory_to_file,
+    zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
@@ -35,8 +39,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let matches = cli().get_matches_from(env::args_os());
     let output = Output::from_matches(&matches);
+
+    match matches.subcommand() {
+        Some(("zip", matches)) => run_zip(matches, &output).await,
+        Some(("unzip", matches)) => run_unzip(matches, &output).await,
+        _ => unreachable!("subcommand is required by clap"),
+    }
+}
+
+async fn s3_client() -> aws_sdk_s3::Client {
     let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
-    let client = aws_sdk_s3::Client::from_conf(
+    aws_sdk_s3::Client::from_conf(
         aws_sdk_s3::config::Builder::from(&config)
             .stalled_stream_protection(
                 StalledStreamProtectionConfig::enabled()
@@ -45,17 +58,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     .build(),
             )
             .build(),
-    );
-
-    match matches.subcommand() {
-        Some(("extract", matches)) => run_extract(&client, matches, &output).await,
-        Some(("upload", matches)) => run_upload(&client, matches, &output).await,
-        _ => unreachable!("subcommand is required by clap"),
-    }
+    )
 }
 
-async fn run_extract(
-    client: &aws_sdk_s3::Client,
+async fn run_unzip(
     matches: &ArgMatches,
     output: &Output,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -72,11 +78,15 @@ async fn run_extract(
     let diagnostics = matches.get_flag("diagnostics");
     let ignore_catalog = matches.get_flag("ignore-catalog");
     let report_destination = ReportDestination::from_cli_value(matches.get_one::<String>("report"));
+    let source = parse_zip_source(source)?;
+    let destination = parse_tree_destination(destination)?;
+    validate_delete_extra_destination(delete_extra, &destination)?;
+    validate_diagnostics_source(diagnostics, &source)?;
 
     output.write(&Transcript::running(
-        "Extract",
+        "Unzip",
         vec![
-            format!("{source} -> {destination}"),
+            format!("{} -> {}", source.display(), destination.display()),
             format!(
                 "{} workers{}",
                 concurrency,
@@ -85,65 +95,109 @@ async fn run_extract(
         ],
     ))?;
 
-    let mut options = SyncOptions::new(S3Object::parse(source)?, S3Prefix::parse(destination)?);
-    options.concurrency = concurrency;
-    options.delete_extra = delete_extra;
-    options.collect_diagnostics = diagnostics;
-    options.collect_operations = !matches!(report_destination, ReportDestination::None);
-    options.ignore_embedded_catalog = ignore_catalog;
-
-    let activity = output.start_activity("Extracting", None);
-    let report = sync_zip_to_s3(client, options).await;
+    let activity = output.start_activity("Unzipping", None);
+    let report = match (source, destination) {
+        (ZipSource::S3(source), TreeDestination::S3(destination)) => {
+            let client = s3_client().await;
+            let mut options = SyncOptions::new(source, destination);
+            options.concurrency = concurrency;
+            options.delete_extra = delete_extra;
+            options.collect_diagnostics = diagnostics;
+            options.collect_operations = !matches!(report_destination, ReportDestination::None);
+            options.ignore_embedded_catalog = ignore_catalog;
+            UnzipCommandReport::S3(sync_zip_to_s3(&client, options).await?)
+        }
+        (ZipSource::Local(source_zip), TreeDestination::S3(destination)) => {
+            let client = s3_client().await;
+            let mut options = LocalZipSyncOptions::new(source_zip, destination);
+            options.concurrency = concurrency;
+            options.delete_extra = delete_extra;
+            options.collect_operations = !matches!(report_destination, ReportDestination::None);
+            options.ignore_embedded_catalog = ignore_catalog;
+            UnzipCommandReport::LocalZipToS3(unzip_file_to_s3(&client, options).await?)
+        }
+        (ZipSource::S3(source), TreeDestination::Local(destination_dir)) => {
+            let client = s3_client().await;
+            let mut options = S3ZipLocalUnzipOptions::new(source, destination_dir);
+            options.concurrency = concurrency;
+            options.collect_diagnostics = diagnostics;
+            options.collect_operations = !matches!(report_destination, ReportDestination::None);
+            options.ignore_embedded_catalog = ignore_catalog;
+            UnzipCommandReport::Local(unzip_s3_zip_to_local(&client, options).await?)
+        }
+        (ZipSource::Local(source_zip), TreeDestination::Local(destination_dir)) => {
+            let mut options = LocalUnzipOptions::new(source_zip, destination_dir);
+            options.concurrency = concurrency;
+            options.collect_operations = !matches!(report_destination, ReportDestination::None);
+            options.ignore_embedded_catalog = ignore_catalog;
+            UnzipCommandReport::Local(unzip_file_to_local(options).await?)
+        }
+    };
     activity.finish().await;
-    let report = report?;
-    write_report(&report_destination, &report).await?;
-    output.write(&extract_transcript(&report, &report_destination))?;
+    report.write(&report_destination).await?;
+    output.write(&unzip_transcript(&report, &report_destination))?;
 
     if report.has_errors() {
         return Err(
-            "extract completed with per-object errors; rerun with --report for details".into(),
+            "unzip completed with per-entry errors; rerun with --report for details".into(),
         );
     }
 
     Ok(())
 }
 
-async fn run_upload(
-    client: &aws_sdk_s3::Client,
-    matches: &ArgMatches,
-    output: &Output,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let source_dir = matches
-        .get_one::<PathBuf>("source-dir")
+async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn std::error::Error>> {
+    let source = matches
+        .get_one::<String>("source")
         .expect("required by clap");
     let destination = matches
-        .get_one::<String>("destination-zip")
+        .get_one::<String>("destination")
         .expect("required by clap");
     let report_destination = ReportDestination::from_cli_value(matches.get_one::<String>("report"));
+    let source = parse_tree_source(source)?;
+    let destination = parse_zip_destination(destination)?;
 
     output.write(&Transcript::running(
-        "Upload",
-        vec![format!("{} -> {destination}", source_dir.display())],
+        "Zip",
+        vec![format!("{} -> {}", source.display(), destination.display())],
     ))?;
 
     let progress_detail = ActivityDetail::default();
-    let mut options = UploadOptions::new(source_dir, S3Object::parse(destination)?);
     let progress_sink = progress_detail.clone();
-    options.progress = Some(UploadProgressHandler::new(move |progress| {
+    let progress = UploadProgressHandler::new(move |progress| {
         progress_sink.set(upload_progress_state(&progress));
-    }));
-    let activity = output.start_activity("Uploading", Some(progress_detail));
-    let upload_started = Instant::now();
-    let report = upload_directory_zip_to_s3(client, options).await;
+    });
+    let activity = output.start_activity("Zipping", Some(progress_detail));
+    let zip_started = Instant::now();
+    let report = match (source, destination) {
+        (TreeSource::Local(source_dir), ZipDestination::S3(destination)) => {
+            let client = s3_client().await;
+            let mut options = UploadOptions::new(source_dir, destination);
+            options.progress = Some(progress);
+            ZipCommandReport::Upload(upload_directory_zip_to_s3(&client, options).await?)
+        }
+        (TreeSource::Local(source_dir), ZipDestination::Local(destination_zip)) => {
+            let mut options = LocalZipOptions::new(source_dir, destination_zip);
+            options.progress = Some(progress);
+            ZipCommandReport::Local(zip_directory_to_file(options).await?)
+        }
+        (TreeSource::S3(source), ZipDestination::S3(destination)) => {
+            let client = s3_client().await;
+            let mut options = S3PrefixUploadOptions::new(source, destination);
+            options.progress = Some(progress);
+            ZipCommandReport::S3Prefix(zip_s3_prefix_to_s3(&client, options).await?)
+        }
+        (TreeSource::S3(source), ZipDestination::Local(destination_zip)) => {
+            let client = s3_client().await;
+            let mut options = S3PrefixLocalZipOptions::new(source, destination_zip);
+            options.progress = Some(progress);
+            ZipCommandReport::Local(zip_s3_prefix_to_file(&client, options).await?)
+        }
+    };
     activity.finish().await;
-    let upload_elapsed = upload_started.elapsed();
-    let report = report?;
-    write_report(&report_destination, &report).await?;
-    output.write(&upload_transcript(
-        &report,
-        &report_destination,
-        upload_elapsed,
-    ))?;
+    let zip_elapsed = zip_started.elapsed();
+    report.write(&report_destination).await?;
+    output.write(&zip_transcript(&report, &report_destination, zip_elapsed))?;
 
     Ok(())
 }
@@ -177,9 +231,139 @@ impl ReportDestination {
     }
 }
 
+enum TreeSource {
+    Local(PathBuf),
+    S3(S3Prefix),
+}
+
+impl TreeSource {
+    fn display(&self) -> String {
+        match self {
+            Self::Local(path) => path.display().to_string(),
+            Self::S3(prefix) => prefix.uri(),
+        }
+    }
+}
+
+enum TreeDestination {
+    Local(PathBuf),
+    S3(S3Prefix),
+}
+
+impl TreeDestination {
+    fn display(&self) -> String {
+        match self {
+            Self::Local(path) => path.display().to_string(),
+            Self::S3(prefix) => prefix.uri(),
+        }
+    }
+}
+
+enum ZipSource {
+    Local(PathBuf),
+    S3(S3Object),
+}
+
+impl ZipSource {
+    fn display(&self) -> String {
+        match self {
+            Self::Local(path) => path.display().to_string(),
+            Self::S3(object) => object.uri(),
+        }
+    }
+}
+
+enum ZipDestination {
+    Local(PathBuf),
+    S3(S3Object),
+}
+
+impl ZipDestination {
+    fn display(&self) -> String {
+        match self {
+            Self::Local(path) => path.display().to_string(),
+            Self::S3(object) => object.uri(),
+        }
+    }
+}
+
+fn parse_tree_source(value: &str) -> Result<TreeSource, Box<dyn std::error::Error>> {
+    reject_file_uri(value)?;
+    if value.starts_with("s3://") {
+        Ok(TreeSource::S3(S3Prefix::parse(value)?))
+    } else {
+        Ok(TreeSource::Local(PathBuf::from(value)))
+    }
+}
+
+fn parse_tree_destination(value: &str) -> Result<TreeDestination, Box<dyn std::error::Error>> {
+    reject_file_uri(value)?;
+    if value.starts_with("s3://") {
+        Ok(TreeDestination::S3(S3Prefix::parse(value)?))
+    } else {
+        Ok(TreeDestination::Local(PathBuf::from(value)))
+    }
+}
+
+fn parse_zip_source(value: &str) -> Result<ZipSource, Box<dyn std::error::Error>> {
+    reject_file_uri(value)?;
+    if value.starts_with("s3://") {
+        Ok(ZipSource::S3(S3Object::parse(value)?))
+    } else {
+        Ok(ZipSource::Local(PathBuf::from(value)))
+    }
+}
+
+fn parse_zip_destination(value: &str) -> Result<ZipDestination, Box<dyn std::error::Error>> {
+    reject_file_uri(value)?;
+    if value.starts_with("s3://") {
+        Ok(ZipDestination::S3(S3Object::parse(value)?))
+    } else {
+        Ok(ZipDestination::Local(PathBuf::from(value)))
+    }
+}
+
+fn validate_delete_extra_destination(
+    delete_extra: bool,
+    destination: &TreeDestination,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !delete_extra {
+        return Ok(());
+    }
+
+    match destination {
+        TreeDestination::Local(_) => {
+            Err("--delete-extra is only supported for s3:// destinations".into())
+        }
+        TreeDestination::S3(prefix) if prefix.prefix.is_empty() => {
+            Err("--delete-extra requires a non-empty s3:// destination prefix".into())
+        }
+        TreeDestination::S3(_) => Ok(()),
+    }
+}
+
+fn validate_diagnostics_source(
+    diagnostics: bool,
+    source: &ZipSource,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if diagnostics && matches!(source, ZipSource::Local(_)) {
+        Err("--diagnostics is only supported for s3:// ZIP sources".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_file_uri(value: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if value.starts_with("file://") {
+        Err("file:// URIs are not supported; use a plain local path".into())
+    } else {
+        Ok(())
+    }
+}
+
 fn cli() -> Command {
     Command::new("s3-unspool")
-        .about("Upload local directories as S3 ZIPs and extract S3 ZIPs into S3 prefixes")
+        .about("Zip and unzip local paths and S3 prefixes")
         .arg_required_else_help(true)
         .subcommand_required(true)
         .arg(
@@ -200,18 +384,18 @@ fn cli() -> Command {
                 .default_value("auto"),
         )
         .subcommand(
-            Command::new("extract")
-                .about("Extract missing or changed files from an S3 ZIP object into an S3 prefix")
+            Command::new("unzip")
+                .about("Unzip a local or S3 ZIP into a local directory or S3 prefix")
                 .arg(
                     Arg::new("source")
                         .value_name("SOURCE_ZIP")
-                        .help("Source ZIP object, for example s3://bucket/archive.zip")
+                        .help("Source ZIP file, for example ./archive.zip or s3://bucket/archive.zip")
                         .required(true),
                 )
                 .arg(
                     Arg::new("destination")
-                        .value_name("DESTINATION_PREFIX")
-                        .help("Destination S3 prefix, for example s3://bucket/prefix/")
+                        .value_name("DESTINATION_TREE")
+                        .help("Destination tree, for example ./site or s3://bucket/prefix/")
                         .required(true),
                 )
                 .arg(
@@ -240,7 +424,7 @@ fn cli() -> Command {
                 .arg(
                     Arg::new("diagnostics")
                         .long("diagnostics")
-                        .help("Collect aggregate source range, block cache, and PUT retry diagnostics in the JSON report")
+                        .help("Collect source range diagnostics for s3:// ZIP sources in the JSON report")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
@@ -251,19 +435,18 @@ fn cli() -> Command {
                 ),
         )
         .subcommand(
-            Command::new("upload")
-                .about("Zip a local directory and upload the archive to S3")
+            Command::new("zip")
+                .about("Zip a local directory or S3 prefix into a local or S3 ZIP")
                 .arg(
-                    Arg::new("source-dir")
-                        .value_name("LOCAL_DIR")
-                        .help("Local directory whose contents should be zipped")
-                        .value_parser(value_parser!(PathBuf))
+                    Arg::new("source")
+                        .value_name("SOURCE_TREE")
+                        .help("Source tree, for example ./site or s3://bucket/prefix/")
                         .required(true),
                 )
                 .arg(
-                    Arg::new("destination-zip")
+                    Arg::new("destination")
                         .value_name("DESTINATION_ZIP")
-                        .help("Destination ZIP object, for example s3://bucket/archive.zip")
+                        .help("Destination ZIP file, for example ./archive.zip or s3://bucket/archive.zip")
                         .required(true),
                 )
                 .arg(
@@ -273,7 +456,7 @@ fn cli() -> Command {
                         .num_args(0..=1)
                         .require_equals(true)
                         .default_missing_value("-")
-                        .help("Show a formatted upload report, or write JSON to a path with --report=PATH"),
+                        .help("Show a formatted zip report, or write JSON to a path with --report=PATH"),
                 ),
         )
 }
@@ -589,31 +772,181 @@ impl Transcript {
     }
 }
 
-fn upload_transcript(
-    report: &UploadReport,
+enum ZipCommandReport {
+    Upload(UploadReport),
+    S3Prefix(S3PrefixUploadReport),
+    Local(LocalZipReport),
+}
+
+impl ZipCommandReport {
+    async fn write(
+        &self,
+        destination: &ReportDestination,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            Self::Upload(report) => write_report(destination, report).await,
+            Self::S3Prefix(report) => write_report(destination, report).await,
+            Self::Local(report) => write_report(destination, report).await,
+        }
+    }
+
+    fn source(&self) -> String {
+        match self {
+            Self::Upload(report) => report.source_dir.clone(),
+            Self::S3Prefix(report) => report.source.uri(),
+            Self::Local(report) => report.source.clone(),
+        }
+    }
+
+    fn destination(&self) -> String {
+        match self {
+            Self::Upload(report) => report.destination.uri(),
+            Self::S3Prefix(report) => report.destination.uri(),
+            Self::Local(report) => report.destination_zip.clone(),
+        }
+    }
+
+    fn files(&self) -> usize {
+        match self {
+            Self::Upload(report) => report.files,
+            Self::S3Prefix(report) => report.files,
+            Self::Local(report) => report.files,
+        }
+    }
+
+    fn directories(&self) -> usize {
+        match self {
+            Self::Upload(report) => report.directories,
+            Self::S3Prefix(report) => report.directories,
+            Self::Local(report) => report.directories,
+        }
+    }
+
+    fn uncompressed_bytes(&self) -> u64 {
+        match self {
+            Self::Upload(report) => report.uncompressed_bytes,
+            Self::S3Prefix(report) => report.uncompressed_bytes,
+            Self::Local(report) => report.uncompressed_bytes,
+        }
+    }
+
+    fn zip_bytes(&self) -> u64 {
+        match self {
+            Self::Upload(report) => report.zip_bytes,
+            Self::S3Prefix(report) => report.zip_bytes,
+            Self::Local(report) => report.zip_bytes,
+        }
+    }
+}
+
+enum UnzipCommandReport {
+    S3(SyncReport),
+    LocalZipToS3(LocalZipToS3Report),
+    Local(LocalUnzipReport),
+}
+
+impl UnzipCommandReport {
+    async fn write(
+        &self,
+        destination: &ReportDestination,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            Self::S3(report) => write_report(destination, report).await,
+            Self::LocalZipToS3(report) => write_report(destination, report).await,
+            Self::Local(report) => write_report(destination, report).await,
+        }
+    }
+
+    fn has_errors(&self) -> bool {
+        match self {
+            Self::S3(report) => report.has_errors(),
+            Self::LocalZipToS3(report) => report.has_errors(),
+            Self::Local(report) => report.has_errors(),
+        }
+    }
+
+    fn summary(&self) -> &SyncSummary {
+        match self {
+            Self::S3(report) => &report.summary,
+            Self::LocalZipToS3(report) => &report.summary,
+            Self::Local(report) => &report.summary,
+        }
+    }
+
+    fn source(&self) -> String {
+        match self {
+            Self::S3(report) => report.source.uri(),
+            Self::LocalZipToS3(report) => report.source_zip.clone(),
+            Self::Local(report) => report.source_zip.clone(),
+        }
+    }
+
+    fn destination(&self) -> String {
+        match self {
+            Self::S3(report) => report.destination.uri(),
+            Self::LocalZipToS3(report) => report.destination.uri(),
+            Self::Local(report) => report.destination_dir.clone(),
+        }
+    }
+
+    fn operations(&self) -> &[ObjectReport] {
+        match self {
+            Self::S3(report) => &report.operations,
+            Self::LocalZipToS3(report) => &report.operations,
+            Self::Local(report) => &report.operations,
+        }
+    }
+
+    fn diagnostics_line(&self) -> Option<String> {
+        match self {
+            Self::S3(report) => report.diagnostics.as_ref().map(diagnostics_line),
+            Self::Local(report) => report.diagnostics.as_ref().map(|diagnostics| {
+                format!(
+                    "Source: {} GET attempts, {} blocks fetched, {} waits, {:.2}x amplification",
+                    diagnostics.source.source_get_attempts,
+                    diagnostics.source.fetched_blocks,
+                    diagnostics.source.block_waits,
+                    diagnostics.source.source_amplification
+                )
+            }),
+            Self::LocalZipToS3(_) => None,
+        }
+    }
+}
+
+fn zip_transcript(
+    report: &ZipCommandReport,
     report_destination: &ReportDestination,
-    upload_elapsed: Duration,
+    zip_elapsed: Duration,
 ) -> Transcript {
+    let mut counts = vec![plural(report.files(), "file", "files")];
+    let directories = report.directories();
+    if directories > 0 {
+        counts.push(plural(directories, "directory", "directories"));
+    }
     let mut details = vec![
         format!(
             "{}, {} uncompressed, {} ZIP",
-            plural(report.files, "file", "files"),
-            format_bytes(report.uncompressed_bytes),
-            format_bytes(report.zip_bytes)
+            counts.join(", "),
+            format_bytes(report.uncompressed_bytes()),
+            format_bytes(report.zip_bytes())
         ),
-        report.destination.uri(),
+        report.destination(),
     ];
     match report_destination {
         ReportDestination::None => {}
         ReportDestination::JsonFile(path) => details.push(format!("Report: {path}")),
-        ReportDestination::Human => details.extend(upload_report_details(report, upload_elapsed)),
+        ReportDestination::Human => details.extend(zip_report_details(report, zip_elapsed)),
     }
 
-    Transcript::success("Upload complete", details)
+    Transcript::success("Zip complete", details)
 }
 
-fn extract_transcript(report: &SyncReport, report_destination: &ReportDestination) -> Transcript {
-    let summary = &report.summary;
+fn unzip_transcript(
+    report: &UnzipCommandReport,
+    report_destination: &ReportDestination,
+) -> Transcript {
+    let summary = report.summary();
     let mut details = if summary.uploaded_new == 0
         && summary.uploaded_changed == 0
         && summary.deleted_extra == 0
@@ -622,22 +955,24 @@ fn extract_transcript(report: &SyncReport, report_destination: &ReportDestinatio
     {
         vec![format!(
             "{} unchanged",
-            plural(summary.skipped_unchanged, "file", "files")
+            plural(summary.skipped_unchanged, "entry", "entries")
         )]
     } else {
         vec![format!(
             "{}: {} new, {} changed, {} unchanged",
-            plural(summary.zip_files, "file", "files"),
+            plural(summary.zip_files, "entry", "entries"),
             summary.uploaded_new,
             summary.uploaded_changed,
             summary.skipped_unchanged
         )]
     };
 
-    details.push(format!(
-        "Destination: {} listed",
-        plural(summary.destination_objects, "object", "objects")
-    ));
+    if summary.destination_objects > 0 {
+        details.push(format!(
+            "Destination: {} listed",
+            plural(summary.destination_objects, "object", "objects")
+        ));
+    }
     if summary.deleted_extra > 0 {
         details.push(format!(
             "Deleted: {} extra",
@@ -657,64 +992,64 @@ fn extract_transcript(report: &SyncReport, report_destination: &ReportDestinatio
     if summary.errors > 0 {
         details.push(format!(
             "Errors: {}",
-            plural(summary.errors, "object", "objects")
+            plural(summary.errors, "entry", "entries")
         ));
     }
-    if let Some(diagnostics) = &report.diagnostics {
-        details.push(diagnostics_line(diagnostics));
+    if let Some(line) = report.diagnostics_line() {
+        details.push(line);
     }
     match report_destination {
         ReportDestination::None => {}
         ReportDestination::JsonFile(path) => details.push(format!("Report: {path}")),
-        ReportDestination::Human => details.extend(extract_report_details(report)),
+        ReportDestination::Human => details.extend(unzip_report_details(report)),
     }
 
     if summary.errors > 0 {
-        Transcript::error("Extract completed with errors", details)
+        Transcript::error("Unzip completed with errors", details)
     } else if summary.conditional_conflicts > 0 {
-        Transcript::notice("Extract completed with conflicts", details)
+        Transcript::notice("Unzip completed with conflicts", details)
     } else if summary.uploaded_new == 0
         && summary.uploaded_changed == 0
         && summary.deleted_extra == 0
     {
         Transcript::success("Up to date", details)
     } else {
-        Transcript::success("Extract complete", details)
+        Transcript::success("Unzip complete", details)
     }
 }
 
-fn upload_report_details(report: &UploadReport, upload_elapsed: Duration) -> Vec<String> {
+fn zip_report_details(report: &ZipCommandReport, zip_elapsed: Duration) -> Vec<String> {
     vec![
         "Report:".to_string(),
-        format!("  Source: {}", report.source_dir),
-        format!("  Destination: {}", report.destination.uri()),
-        format!("  Files: {}", plural(report.files, "file", "files")),
+        format!("  Source: {}", report.source()),
+        format!("  Destination: {}", report.destination()),
+        format!("  Files: {}", plural(report.files(), "file", "files")),
+        format!(
+            "  Directories: {}",
+            plural(report.directories(), "directory", "directories")
+        ),
         format!(
             "  Uncompressed: {}",
-            format_bytes(report.uncompressed_bytes)
+            format_bytes(report.uncompressed_bytes())
         ),
-        format!("  ZIP: {}", format_bytes(report.zip_bytes)),
-        format!("  Wall time: {}", format_elapsed(upload_elapsed)),
+        format!("  ZIP: {}", format_bytes(report.zip_bytes())),
+        format!("  Wall time: {}", format_elapsed(zip_elapsed)),
         format!(
-            "  Upload speed: {}",
-            format_upload_speed(report.zip_bytes, upload_elapsed)
+            "  Zip speed: {}",
+            format_upload_speed(report.zip_bytes(), zip_elapsed)
         ),
     ]
 }
 
-fn extract_report_details(report: &SyncReport) -> Vec<String> {
-    let summary = &report.summary;
+fn unzip_report_details(report: &UnzipCommandReport) -> Vec<String> {
+    let summary = report.summary();
     let mut details = vec![
         "Report:".to_string(),
-        format!("  Source: {}", report.source.uri()),
-        format!("  Destination: {}", report.destination.uri()),
+        format!("  Source: {}", report.source()),
+        format!("  Destination: {}", report.destination()),
         format!(
-            "  ZIP files: {}",
-            plural(summary.zip_files, "file", "files")
-        ),
-        format!(
-            "  Destination listed: {}",
-            plural(summary.destination_objects, "object", "objects")
+            "  ZIP entries: {}",
+            plural(summary.zip_files, "entry", "entries")
         ),
         format!(
             "  Operations: {} new, {} changed, {} unchanged, {} deleted",
@@ -725,17 +1060,23 @@ fn extract_report_details(report: &SyncReport) -> Vec<String> {
         ),
     ];
 
+    if summary.destination_objects > 0 {
+        details.push(format!(
+            "  Destination listed: {}",
+            plural(summary.destination_objects, "object", "objects")
+        ));
+    }
     if summary.conditional_conflicts > 0 || summary.errors > 0 {
         details.push(format!(
             "  Issues: {} conflicts, {} errors",
             summary.conditional_conflicts, summary.errors
         ));
     }
-    if let Some(diagnostics) = &report.diagnostics {
-        details.push(format!("  {}", diagnostics_line(diagnostics)));
+    if let Some(line) = report.diagnostics_line() {
+        details.push(format!("  {line}"));
     }
 
-    details.extend(operation_report_details(&report.operations));
+    details.extend(operation_report_details(report.operations()));
     details
 }
 
@@ -1089,14 +1430,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_extract_subcommand() {
+    fn parses_unzip_subcommand() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
                 "--quiet",
                 "--color",
                 "never",
-                "extract",
+                "unzip",
                 "--delete-extra",
                 "--ignore-catalog",
                 "s3://source-bucket/archive.zip",
@@ -1110,8 +1451,8 @@ mod tests {
             Some("never")
         );
 
-        let Some(("extract", extract)) = matches.subcommand() else {
-            panic!("expected extract subcommand");
+        let Some(("unzip", extract)) = matches.subcommand() else {
+            panic!("expected unzip subcommand");
         };
         assert!(extract.get_flag("delete-extra"));
         assert!(extract.get_flag("ignore-catalog"));
@@ -1122,45 +1463,130 @@ mod tests {
     }
 
     #[test]
-    fn parses_upload_subcommand() {
+    fn parses_zip_subcommand() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "upload",
+                "zip",
                 "/tmp/site",
                 "s3://destination-bucket/site.zip",
             ])
             .unwrap();
 
-        let Some(("upload", upload)) = matches.subcommand() else {
-            panic!("expected upload subcommand");
+        let Some(("zip", upload)) = matches.subcommand() else {
+            panic!("expected zip subcommand");
         };
         assert_eq!(
-            upload.get_one::<PathBuf>("source-dir"),
-            Some(&PathBuf::from("/tmp/site"))
+            upload.get_one::<String>("source").map(String::as_str),
+            Some("/tmp/site")
         );
         assert_eq!(
-            upload
-                .get_one::<String>("destination-zip")
-                .map(String::as_str),
+            upload.get_one::<String>("destination").map(String::as_str),
             Some("s3://destination-bucket/site.zip")
         );
     }
 
     #[test]
-    fn parses_bare_report_as_stdout_for_extract() {
+    fn parses_all_zip_endpoint_combinations() {
+        for (source, destination) in [
+            ("/tmp/site", "/tmp/site.zip"),
+            ("/tmp/site", "s3://bucket/site.zip"),
+            ("s3://bucket/site/", "/tmp/site.zip"),
+            ("s3://bucket/site/", "s3://bucket/site.zip"),
+        ] {
+            let matches = cli()
+                .try_get_matches_from(["s3-unspool", "zip", source, destination])
+                .unwrap();
+            let Some(("zip", zip)) = matches.subcommand() else {
+                panic!("expected zip subcommand");
+            };
+            assert_eq!(
+                zip.get_one::<String>("source").map(String::as_str),
+                Some(source)
+            );
+            assert_eq!(
+                zip.get_one::<String>("destination").map(String::as_str),
+                Some(destination)
+            );
+        }
+    }
+
+    #[test]
+    fn parses_all_unzip_endpoint_combinations() {
+        for (source, destination) in [
+            ("/tmp/site.zip", "/tmp/site"),
+            ("/tmp/site.zip", "s3://bucket/site/"),
+            ("s3://bucket/site.zip", "/tmp/site"),
+            ("s3://bucket/site.zip", "s3://bucket/site/"),
+        ] {
+            let matches = cli()
+                .try_get_matches_from(["s3-unspool", "unzip", source, destination])
+                .unwrap();
+            let Some(("unzip", unzip)) = matches.subcommand() else {
+                panic!("expected unzip subcommand");
+            };
+            assert_eq!(
+                unzip.get_one::<String>("source").map(String::as_str),
+                Some(source)
+            );
+            assert_eq!(
+                unzip.get_one::<String>("destination").map(String::as_str),
+                Some(destination)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_file_uri_endpoint_values() {
+        assert!(parse_tree_source("file:///tmp/site").is_err());
+        assert!(parse_zip_source("file:///tmp/site.zip").is_err());
+        assert!(parse_tree_destination("file:///tmp/site").is_err());
+        assert!(parse_zip_destination("file:///tmp/site.zip").is_err());
+    }
+
+    #[test]
+    fn rejects_delete_extra_for_bucket_root_destination() {
+        let destination = parse_tree_destination("s3://bucket").unwrap();
+
+        let err = validate_delete_extra_destination(true, &destination).unwrap_err();
+
+        assert!(err.to_string().contains("non-empty"));
+    }
+
+    #[test]
+    fn rejects_delete_extra_for_local_destination() {
+        let destination = parse_tree_destination("/tmp/site").unwrap();
+
+        let err = validate_delete_extra_destination(true, &destination).unwrap_err();
+
+        assert!(err.to_string().contains("s3://"));
+    }
+
+    #[test]
+    fn rejects_diagnostics_for_local_zip_sources() {
+        let source = parse_zip_source("/tmp/site.zip").unwrap();
+
+        let err = validate_diagnostics_source(true, &source).unwrap_err();
+
+        assert!(err.to_string().contains("s3:// ZIP sources"));
+        let source = parse_zip_source("s3://bucket/site.zip").unwrap();
+        validate_diagnostics_source(true, &source).unwrap();
+    }
+
+    #[test]
+    fn parses_bare_report_as_stdout_for_unzip() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "extract",
+                "unzip",
                 "--report",
                 "s3://source-bucket/archive.zip",
                 "s3://destination-bucket/prefix/",
             ])
             .unwrap();
 
-        let Some(("extract", extract)) = matches.subcommand() else {
-            panic!("expected extract subcommand");
+        let Some(("unzip", extract)) = matches.subcommand() else {
+            panic!("expected unzip subcommand");
         };
         assert_eq!(
             extract.get_one::<String>("report").map(String::as_str),
@@ -1173,19 +1599,19 @@ mod tests {
     }
 
     #[test]
-    fn parses_report_path_for_extract() {
+    fn parses_report_path_for_unzip() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "extract",
+                "unzip",
                 "--report=report.json",
                 "s3://source-bucket/archive.zip",
                 "s3://destination-bucket/prefix/",
             ])
             .unwrap();
 
-        let Some(("extract", extract)) = matches.subcommand() else {
-            panic!("expected extract subcommand");
+        let Some(("unzip", extract)) = matches.subcommand() else {
+            panic!("expected unzip subcommand");
         };
         assert_eq!(
             extract.get_one::<String>("report").map(String::as_str),
@@ -1194,19 +1620,19 @@ mod tests {
     }
 
     #[test]
-    fn parses_report_path_after_extract_positionals() {
+    fn parses_report_path_after_unzip_positionals() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "extract",
+                "unzip",
                 "s3://source-bucket/archive.zip",
                 "s3://destination-bucket/prefix/",
                 "--report=report.json",
             ])
             .unwrap();
 
-        let Some(("extract", extract)) = matches.subcommand() else {
-            panic!("expected extract subcommand");
+        let Some(("unzip", extract)) = matches.subcommand() else {
+            panic!("expected unzip subcommand");
         };
         assert_eq!(
             extract.get_one::<String>("report").map(String::as_str),
@@ -1219,7 +1645,7 @@ mod tests {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "extract",
+                "unzip",
                 "--report",
                 "--concurrency=32",
                 "s3://source-bucket/archive.zip",
@@ -1227,8 +1653,8 @@ mod tests {
             ])
             .unwrap();
 
-        let Some(("extract", extract)) = matches.subcommand() else {
-            panic!("expected extract subcommand");
+        let Some(("unzip", extract)) = matches.subcommand() else {
+            panic!("expected unzip subcommand");
         };
         assert_eq!(
             extract.get_one::<String>("report").map(String::as_str),
@@ -1242,44 +1668,44 @@ mod tests {
     }
 
     #[test]
-    fn parses_bare_report_as_stdout_for_upload() {
+    fn parses_bare_report_as_stdout_for_zip() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "upload",
+                "zip",
                 "--report",
                 "/tmp/site",
                 "s3://destination-bucket/site.zip",
             ])
             .unwrap();
 
-        let Some(("upload", upload)) = matches.subcommand() else {
-            panic!("expected upload subcommand");
+        let Some(("zip", upload)) = matches.subcommand() else {
+            panic!("expected zip subcommand");
         };
         assert_eq!(
             upload.get_one::<String>("report").map(String::as_str),
             Some("-")
         );
         assert_eq!(
-            upload.get_one::<PathBuf>("source-dir"),
-            Some(&PathBuf::from("/tmp/site"))
+            upload.get_one::<String>("source").map(String::as_str),
+            Some("/tmp/site")
         );
     }
 
     #[test]
-    fn parses_report_dash_as_stdout_for_upload() {
+    fn parses_report_dash_as_stdout_for_zip() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "upload",
+                "zip",
                 "--report=-",
                 "/tmp/site",
                 "s3://destination-bucket/site.zip",
             ])
             .unwrap();
 
-        let Some(("upload", upload)) = matches.subcommand() else {
-            panic!("expected upload subcommand");
+        let Some(("zip", upload)) = matches.subcommand() else {
+            panic!("expected zip subcommand");
         };
         assert_eq!(
             upload.get_one::<String>("report").map(String::as_str),
@@ -1288,19 +1714,19 @@ mod tests {
     }
 
     #[test]
-    fn parses_report_path_for_upload() {
+    fn parses_report_path_for_zip() {
         let matches = cli()
             .try_get_matches_from([
                 "s3-unspool",
-                "upload",
+                "zip",
                 "--report=report.json",
                 "/tmp/site",
                 "s3://destination-bucket/site.zip",
             ])
             .unwrap();
 
-        let Some(("upload", upload)) = matches.subcommand() else {
-            panic!("expected upload subcommand");
+        let Some(("zip", upload)) = matches.subcommand() else {
+            panic!("expected zip subcommand");
         };
         assert_eq!(
             upload.get_one::<String>("report").map(String::as_str),
@@ -1309,48 +1735,53 @@ mod tests {
     }
 
     #[test]
-    fn renders_upload_transcript() {
+    fn renders_zip_transcript() {
         let report = UploadReport {
             source_dir: "./site".to_string(),
             destination: S3Object::parse("s3://bucket/site.zip").unwrap(),
             files: 2,
+            directories: 0,
             uncompressed_bytes: 1536,
             zip_bytes: 768,
         };
 
-        let transcript = upload_transcript(
-            &report,
+        let transcript = zip_transcript(
+            &ZipCommandReport::Upload(report),
             &ReportDestination::JsonFile("report.json".to_string()),
             Duration::from_secs(2),
         );
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "✓ Upload complete\n  └ 2 files, 1.5 KiB uncompressed, 768 B ZIP\n    s3://bucket/site.zip\n    Report: report.json"
+            "✓ Zip complete\n  └ 2 files, 1.5 KiB uncompressed, 768 B ZIP\n    s3://bucket/site.zip\n    Report: report.json"
         );
     }
 
     #[test]
-    fn renders_upload_transcript_with_human_report() {
+    fn renders_zip_transcript_with_human_report() {
         let report = UploadReport {
             source_dir: "./site".to_string(),
             destination: S3Object::parse("s3://bucket/site.zip").unwrap(),
             files: 2,
+            directories: 1,
             uncompressed_bytes: 4 * 1024 * 1024,
             zip_bytes: 3 * 1024 * 1024,
         };
 
-        let transcript =
-            upload_transcript(&report, &ReportDestination::Human, Duration::from_secs(2));
+        let transcript = zip_transcript(
+            &ZipCommandReport::Upload(report),
+            &ReportDestination::Human,
+            Duration::from_secs(2),
+        );
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "✓ Upload complete\n  └ 2 files, 4.0 MiB uncompressed, 3.0 MiB ZIP\n    s3://bucket/site.zip\n    Report:\n      Source: ./site\n      Destination: s3://bucket/site.zip\n      Files: 2 files\n      Uncompressed: 4.0 MiB\n      ZIP: 3.0 MiB\n      Wall time: 00:02\n      Upload speed: 1.50 MiB/s"
+            "✓ Zip complete\n  └ 2 files, 1 directory, 4.0 MiB uncompressed, 3.0 MiB ZIP\n    s3://bucket/site.zip\n    Report:\n      Source: ./site\n      Destination: s3://bucket/site.zip\n      Files: 2 files\n      Directories: 1 directory\n      Uncompressed: 4.0 MiB\n      ZIP: 3.0 MiB\n      Wall time: 00:02\n      Zip speed: 1.50 MiB/s"
         );
     }
 
     #[test]
-    fn renders_up_to_date_extract_transcript() {
+    fn renders_up_to_date_unzip_transcript() {
         let report = SyncReport {
             source: S3Object::parse("s3://bucket/site.zip").unwrap(),
             destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
@@ -1364,16 +1795,17 @@ mod tests {
             operations: Vec::new(),
         };
 
-        let transcript = extract_transcript(&report, &ReportDestination::None);
+        let transcript =
+            unzip_transcript(&UnzipCommandReport::S3(report), &ReportDestination::None);
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "✓ Up to date\n  └ 10 files unchanged\n    Destination: 10 objects listed"
+            "✓ Up to date\n  └ 10 entries unchanged\n    Destination: 10 objects listed"
         );
     }
 
     #[test]
-    fn renders_changed_extract_transcript_with_diagnostics() {
+    fn renders_changed_unzip_transcript_with_diagnostics() {
         let report = SyncReport {
             source: S3Object::parse("s3://bucket/site.zip").unwrap(),
             destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
@@ -1428,19 +1860,19 @@ mod tests {
             operations: Vec::new(),
         };
 
-        let transcript = extract_transcript(
-            &report,
+        let transcript = unzip_transcript(
+            &UnzipCommandReport::S3(report),
             &ReportDestination::JsonFile("report.json".to_string()),
         );
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "✓ Extract complete\n  └ 10 files: 1 new, 2 changed, 7 unchanged\n    Destination: 12 objects listed\n    Deleted: 1 object extra\n    Source: 3 GET attempts, 2 blocks fetched, 1 waits, 1.25x amplification\n    Report: report.json"
+            "✓ Unzip complete\n  └ 10 entries: 1 new, 2 changed, 7 unchanged\n    Destination: 12 objects listed\n    Deleted: 1 object extra\n    Source: 3 GET attempts, 2 blocks fetched, 1 waits, 1.25x amplification\n    Report: report.json"
         );
     }
 
     #[test]
-    fn renders_extract_transcript_with_human_report() {
+    fn renders_unzip_transcript_with_human_report() {
         let report = SyncReport {
             source: S3Object::parse("s3://bucket/site.zip").unwrap(),
             destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
@@ -1484,16 +1916,17 @@ mod tests {
             ],
         };
 
-        let transcript = extract_transcript(&report, &ReportDestination::Human);
+        let transcript =
+            unzip_transcript(&UnzipCommandReport::S3(report), &ReportDestination::Human);
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "✓ Extract complete\n  └ 3 files: 1 new, 1 changed, 1 unchanged\n    Destination: 2 objects listed\n    Report:\n      Source: s3://bucket/site.zip\n      Destination: s3://bucket/www/\n      ZIP files: 3 files\n      Destination listed: 2 objects\n      Operations: 1 new, 1 changed, 1 unchanged, 0 deleted\n      Objects:\n        uploaded new: www/a.txt (10 B)\n        uploaded changed: www/b.txt (20 B)"
+            "✓ Unzip complete\n  └ 3 entries: 1 new, 1 changed, 1 unchanged\n    Destination: 2 objects listed\n    Report:\n      Source: s3://bucket/site.zip\n      Destination: s3://bucket/www/\n      ZIP entries: 3 entries\n      Operations: 1 new, 1 changed, 1 unchanged, 0 deleted\n      Destination listed: 2 objects\n      Objects:\n        uploaded new: www/a.txt (10 B)\n        uploaded changed: www/b.txt (20 B)"
         );
     }
 
     #[test]
-    fn renders_conflict_extract_transcript() {
+    fn renders_conflict_unzip_transcript() {
         let report = SyncReport {
             source: S3Object::parse("s3://bucket/site.zip").unwrap(),
             destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
@@ -1509,11 +1942,12 @@ mod tests {
             operations: Vec::new(),
         };
 
-        let transcript = extract_transcript(&report, &ReportDestination::None);
+        let transcript =
+            unzip_transcript(&UnzipCommandReport::S3(report), &ReportDestination::None);
 
         assert_eq!(
             transcript.render(Theme { color: false }),
-            "! Extract completed with conflicts\n  └ 3 files: 0 new, 1 changed, 1 unchanged\n    Destination: 3 objects listed\n    Conflicts: 1 conditional write"
+            "! Unzip completed with conflicts\n  └ 3 entries: 0 new, 1 changed, 1 unchanged\n    Destination: 3 objects listed\n    Conflicts: 1 conditional write"
         );
     }
 

--- a/crates/s3-unspool/README.md
+++ b/crates/s3-unspool/README.md
@@ -4,11 +4,11 @@
 archives from S3 into S3 prefixes.
 
 It is designed for large archives and low scratch-space environments: the source
-ZIP is read with ranged S3 `GetObject` calls, extracted files are streamed
-directly into S3 `PutObject` requests, and no local ZIP or extracted entry files
-are written. The crate also includes an upload helper that streams a local
-directory into a ZIP object in S3 and embeds the catalog used by later
-incremental extracts.
+ZIP is read with ranged S3 `GetObject` calls, and extracted files can be
+streamed directly into S3 `PutObject` requests or written to a local directory.
+The crate also includes zip helpers that stream a local directory or existing S3
+prefix into a local or S3 ZIP and embed the catalog used by later incremental
+extracts.
 
 ## Install
 
@@ -50,7 +50,8 @@ async fn main() -> s3_unspool::Result<()> {
 ### Upload a Directory as a Cataloged ZIP
 
 Use `upload_directory_zip_to_s3` when you want the crate to produce the source
-ZIP and embed the catalog used by fast future extracts.
+ZIP and embed the catalog used by fast future extracts. Empty local directories
+are written as ZIP directory entries.
 
 ```rust
 use aws_config::BehaviorVersion;
@@ -74,6 +75,34 @@ async fn main() -> s3_unspool::Result<()> {
 }
 ```
 
+### Upload an S3 Prefix as a Cataloged ZIP
+
+Use `zip_s3_prefix_to_s3` when the source files already live in S3 and should be
+snapshotted into a ZIP object without local object storage. Use
+`zip_s3_prefix_to_file` when the ZIP destination should be a local file instead.
+
+```rust
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::Client;
+use s3_unspool::{S3Object, S3Prefix, S3PrefixUploadOptions, zip_s3_prefix_to_s3};
+
+#[tokio::main]
+async fn main() -> s3_unspool::Result<()> {
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let client = Client::new(&config);
+
+    let upload = S3PrefixUploadOptions::new(
+        S3Prefix::parse("s3://my-bucket/www/")?,
+        S3Object::parse("s3://my-bucket/releases/site.zip")?,
+    );
+    let report = zip_s3_prefix_to_s3(&client, upload).await?;
+
+    println!("uploaded {} files", report.files);
+
+    Ok(())
+}
+```
+
 ## Behavior
 
 - Reads source ZIP data with ranged S3 `GetObject` requests.
@@ -84,7 +113,9 @@ async fn main() -> s3_unspool::Result<()> {
 - Optionally deletes destination objects that are not present in the ZIP.
 - Supports Stored and Deflate ZIP entries.
 - Uploads generated source ZIPs with S3 multipart upload.
-- Emits optional upload progress events through `UploadOptions::progress`.
+- Uploads existing S3 prefixes into generated ZIPs without local object storage.
+- Preserves ZIP directory entries and zero-byte S3 folder marker objects.
+- Emits optional upload progress events through upload option progress handlers.
 - Can ignore the embedded catalog with `SyncOptions::ignore_embedded_catalog`
   when you need to force the fallback extract-and-hash comparison path.
 - Can fail fast on destination write races with
@@ -106,6 +137,10 @@ Extraction needs:
 | Destination prefix | `s3:PutObject` | Write missing and changed objects. |
 | Destination prefix | `s3:GetObject` | Authorize conditional overwrites with `If-Match`. |
 | Destination prefix | `s3:DeleteObject` | Only needed when `delete_extra` is enabled. |
+
+S3-prefix upload additionally needs `s3:ListBucket` for the source bucket,
+`s3:GetObject` for the source prefix, and multipart-upload write permissions for
+the destination ZIP object.
 
 The destination `s3:GetObject` permission is required even though
 `s3-unspool` does not issue per-file destination `HeadObject` requests or read
@@ -135,6 +170,11 @@ ZIPs created by `upload_directory_zip_to_s3` include an embedded catalog at
 `.s3-unspool/catalog.v1.json`. The catalog stores each file path and MD5 digest
 so later extracts can skip unchanged files before decompressing them.
 
+Directory markers are preserved explicitly. ZIP directory entries such as
+`assets/empty/` extract to zero-byte S3 objects with trailing-slash keys, and
+empty local directories or zero-byte S3 keys ending in `/` upload as ZIP
+directory entries. Nonzero S3 objects ending in `/` are rejected as ambiguous.
+
 ## Assumptions
 
 - Destination objects are written with single-part `PutObject`.
@@ -142,6 +182,7 @@ so later extracts can skip unchanged files before decompressing them.
 - Multipart destination objects and SSE-C destination ETags are out of scope for
   comparison.
 - Destination writes use single `PutObject` requests, not multipart upload.
+- S3-prefix upload rejects nonzero objects whose keys end in `/`.
 
 The CLI and Lambda harness live in the repository workspace, but they are not
 included in the published `s3-unspool` crate.

--- a/crates/s3-unspool/src/entry_reader.rs
+++ b/crates/s3-unspool/src/entry_reader.rs
@@ -24,6 +24,13 @@ pub(crate) async fn entry_reader(
     store: Arc<BlockStore>,
     entry: &ManifestEntry,
 ) -> Result<EntryReader> {
+    if entry.is_directory {
+        return Err(Error::InvalidZipEntry {
+            path: entry.zip_path.clone(),
+            reason: "directory entries do not have file data".to_string(),
+        });
+    }
+
     let mut reader = BlockRangeReader::new(store, entry.source_offset, entry.source_span_end)?;
     let local_header_end = entry
         .source_offset

--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -1,8 +1,11 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use async_zip::tokio::read::fs::ZipFileReader;
+use async_zip::{Compression, StoredZipEntry};
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
@@ -16,26 +19,37 @@ use futures_util::stream::{self, StreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;
 use md5::{Digest, Md5};
+use tokio::io::AsyncRead;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::io::ReaderStream;
 
+use crate::catalog::{EmbeddedCatalog, catalog_md5_by_path};
+use crate::constants::{EMBEDDED_CATALOG_MAX_BYTES, EMBEDDED_CATALOG_PATH};
 use crate::constants::{MAX_BODY_CHUNK_SIZE, MAX_PIPE_CAPACITY};
 use crate::entry_reader::{EntryReader, entry_reader};
 use crate::error::{Error, Result, aws_error_context, aws_error_message};
-use crate::options::{PutRetryPolicy, RetryJitter, SyncOptions, adaptive_source_window_capacity};
+use crate::options::{
+    LocalUnzipOptions, LocalZipSyncOptions, PutRetryPolicy, RetryJitter, S3ZipLocalUnzipOptions,
+    SyncOptions, adaptive_source_window_capacity,
+};
 use crate::range::{
     BlockStore, SourceClient, SourceDiagnosticsCollector, plan_source_blocks,
     start_source_scheduler,
 };
 use crate::report::{
-    ObjectReport, OperationStatus, PutDiagnostics, PutRetryDiagnostics, SyncDiagnostics,
-    SyncReport, SyncSummary, summarize_operation,
+    LocalUnzipDiagnostics, LocalUnzipReport, LocalZipToS3Report, ObjectReport, OperationStatus,
+    PutDiagnostics, PutRetryDiagnostics, SyncDiagnostics, SyncReport, SyncSummary,
+    summarize_operation,
 };
 use crate::s3_uri::{S3Prefix, normalize_etag};
 use crate::source::head_source;
-use crate::zip_manifest::{ManifestEntry, load_zip_manifest, validate_crc32_value};
+use crate::upload::{invalid_local_path, replace_temp_file, temp_sibling_path};
+use crate::zip_manifest::{
+    ManifestEntry, load_zip_manifest, normalize_zip_entry_path, validate_crc32_value,
+};
 
 const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(30);
 const PUT_OBJECT_PRODUCER_ERROR_GRACE: Duration = Duration::from_millis(25);
@@ -380,6 +394,7 @@ pub async fn sync_zip_to_s3_with_clients(
         &options.destination,
         options.ignore_embedded_catalog,
         options.source_block_size,
+        Some(crate::constants::S3_SINGLE_PUT_LIMIT),
     )
     .await?;
     resolve_source_window_capacity(&mut options, source_head.len, manifest.entries.len());
@@ -619,6 +634,1530 @@ pub async fn sync_zip_to_s3_with_clients(
     Ok(report)
 }
 
+/// Extracts a local ZIP file into an S3 prefix.
+///
+/// Entries are streamed from the local ZIP file and written to S3 with
+/// conditional `PutObject` requests after listing the destination prefix.
+pub async fn unzip_file_to_s3(
+    client: &Client,
+    options: LocalZipSyncOptions,
+) -> Result<LocalZipToS3Report> {
+    validate_local_zip_sync_options(&options)?;
+    let reader = open_local_zip_reader(&options.source_zip).await?;
+    let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
+    let mut entries = local_zip_entries_for_s3(
+        reader.file().entries(),
+        &options.destination,
+        source_len,
+        true,
+    )?;
+    if !options.ignore_embedded_catalog {
+        let catalog = load_local_embedded_catalog(&reader, entries.catalog_index).await;
+        apply_local_catalog(&mut entries.entries, catalog);
+    }
+
+    let destination_objects = list_destination(client, &options.destination).await?;
+    let expected_keys = options.delete_extra.then(|| {
+        entries
+            .entries
+            .iter()
+            .map(|entry| entry.destination.clone())
+            .collect::<HashSet<_>>()
+    });
+    let total_entries = entries.entries.len();
+    let mut summary = SyncSummary {
+        zip_files: total_entries,
+        destination_objects: destination_objects.len(),
+        ..SyncSummary::default()
+    };
+    let mut operations = Vec::new();
+
+    let mut stream = stream::iter(entries.entries)
+        .map(|entry| {
+            unzip_local_entry_to_s3(client, &reader, entry, &destination_objects, &options)
+        })
+        .buffer_unordered(options.concurrency);
+
+    while let Some(operation) = stream.next().await {
+        summarize_operation(&mut summary, &operation);
+        if options.collect_operations {
+            operations.push(operation);
+        }
+    }
+    drop(stream);
+
+    if options.delete_extra {
+        let expected_keys = expected_keys.expect("delete-extra expected keys are prepared");
+        let extras = destination_objects
+            .keys()
+            .filter(|key| !expected_keys.contains(*key))
+            .cloned()
+            .collect::<Vec<_>>();
+        for operation in delete_extra_objects(client, &options.destination, extras).await {
+            summarize_operation(&mut summary, &operation);
+            if options.collect_operations {
+                operations.push(operation);
+            }
+        }
+    }
+
+    Ok(LocalZipToS3Report {
+        source_zip: options.source_zip.display().to_string(),
+        destination: options.destination,
+        summary,
+        operations,
+    })
+}
+
+/// Extracts an S3 ZIP object into a local directory.
+///
+/// Existing local files are overwritten, ZIP directory entries are created as
+/// local directories, and extra local files are left untouched.
+pub async fn unzip_s3_zip_to_local(
+    client: &Client,
+    mut options: S3ZipLocalUnzipOptions,
+) -> Result<LocalUnzipReport> {
+    validate_s3_zip_local_unzip_options(&options)?;
+    let destination_root = prepare_local_destination_root(&options.destination_dir).await?;
+    let started = Instant::now();
+    let source_head = head_source(client, &options.source).await?;
+    let diagnostics = options
+        .collect_diagnostics
+        .then(|| Arc::new(SourceDiagnosticsCollector::new(source_head.len)));
+    let source = Arc::new(SourceClient {
+        client: client.clone(),
+        bucket: options.source.bucket.clone(),
+        key: options.source.key.clone(),
+        len: source_head.len,
+        etag: source_head.etag,
+        diagnostics: diagnostics.clone(),
+    });
+    let local_destination = S3Prefix {
+        bucket: "__local__".to_string(),
+        prefix: String::new(),
+    };
+    let manifest = load_zip_manifest(
+        Arc::clone(&source),
+        &local_destination,
+        options.ignore_embedded_catalog,
+        options.source_block_size,
+        None,
+    )
+    .await?;
+    resolve_s3_zip_local_window_capacity(&mut options, source_head.len, manifest.entries.len());
+    validate_s3_zip_local_source_range_options(&options, source_head.len)?;
+
+    let entries = manifest.entries;
+    validate_local_destination_zip_paths(entries.iter().map(|entry| entry.zip_path.as_str()))?;
+    let destination_case_insensitive =
+        destination_uses_case_insensitive_paths(&destination_root).await?;
+    validate_local_destination_path_collisions(
+        entries
+            .iter()
+            .map(|entry| (entry.zip_path.as_str(), entry.is_directory)),
+        destination_case_insensitive,
+    )?;
+    let total_entries = entries.len();
+    let progress = Arc::new(ExtractProgress::new(total_entries));
+    let sync_options = local_unzip_source_sync_options(&options);
+    let (store, scheduler) = start_source_phase(
+        Arc::clone(&source),
+        &entries,
+        &sync_options,
+        source_head.len,
+        diagnostics.clone(),
+    );
+    let mut summary = SyncSummary {
+        zip_files: total_entries,
+        ..SyncSummary::default()
+    };
+    let mut operations = if options.collect_operations {
+        Vec::with_capacity(entries.len())
+    } else {
+        Vec::new()
+    };
+    let mut stream = stream::iter(entries)
+        .map(|entry| {
+            let store = Arc::clone(&store);
+            let destination_root = destination_root.clone();
+            async move { unzip_s3_entry_to_local(store, entry, destination_root).await }
+        })
+        .buffer_unordered(options.concurrency);
+
+    while let Some(operation) = stream.next().await {
+        progress.record_operation(&operation);
+        summarize_operation(&mut summary, &operation);
+        if options.collect_operations {
+            operations.push(operation);
+        }
+    }
+    let _ = scheduler.await;
+
+    progress.log_progress(
+        diagnostics.as_deref(),
+        None,
+        started.elapsed(),
+        "local unzip completed",
+    );
+
+    Ok(LocalUnzipReport {
+        source_zip: options.source.uri(),
+        destination_dir: options.destination_dir.display().to_string(),
+        summary,
+        diagnostics: diagnostics.map(|diagnostics| LocalUnzipDiagnostics {
+            concurrency: options.concurrency,
+            source_block_size: options.source_block_size,
+            source_block_merge_gap: options.source_block_merge_gap,
+            source_get_concurrency: options.source_get_concurrency,
+            source_window_capacity: options.source_window_capacity,
+            source: diagnostics.snapshot(),
+        }),
+        operations,
+    })
+}
+
+/// Extracts a local ZIP file into a local directory.
+///
+/// Existing local files are overwritten, ZIP directory entries are created as
+/// local directories, and extra local files are left untouched.
+pub async fn unzip_file_to_local(options: LocalUnzipOptions) -> Result<LocalUnzipReport> {
+    validate_local_unzip_options(&options)?;
+    let destination_root = prepare_local_destination_root(&options.destination_dir).await?;
+    let reader = open_local_zip_reader(&options.source_zip).await?;
+    let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
+    let entries = local_zip_entries_for_local(reader.file().entries(), source_len, false)?.entries;
+    validate_local_destination_zip_paths(entries.iter().map(|entry| entry.zip_path.as_str()))?;
+    let destination_case_insensitive =
+        destination_uses_case_insensitive_paths(&destination_root).await?;
+    validate_local_destination_path_collisions(
+        entries
+            .iter()
+            .map(|entry| (entry.zip_path.as_str(), entry.is_directory)),
+        destination_case_insensitive,
+    )?;
+    reject_local_unzip_source_archive_target(&options.source_zip, &destination_root, &entries)
+        .await?;
+    let total_entries = entries.len();
+    let mut summary = SyncSummary {
+        zip_files: total_entries,
+        ..SyncSummary::default()
+    };
+    let mut operations = Vec::new();
+
+    let mut stream = stream::iter(entries)
+        .map(|entry| unzip_local_entry_to_local(&reader, entry, &destination_root))
+        .buffer_unordered(options.concurrency);
+
+    while let Some(operation) = stream.next().await {
+        summarize_operation(&mut summary, &operation);
+        if options.collect_operations {
+            operations.push(operation);
+        }
+    }
+    drop(stream);
+
+    Ok(LocalUnzipReport {
+        source_zip: options.source_zip.display().to_string(),
+        destination_dir: options.destination_dir.display().to_string(),
+        summary,
+        diagnostics: None,
+        operations,
+    })
+}
+
+type LocalZipReader = ZipFileReader;
+
+#[derive(Clone, Debug)]
+struct LocalZipEntry {
+    index: usize,
+    zip_path: String,
+    destination: String,
+    size: u64,
+    compressed_size: u64,
+    compression: Compression,
+    crc32: u32,
+    catalog_md5: Option<String>,
+    is_directory: bool,
+}
+
+struct LocalZipEntries {
+    entries: Vec<LocalZipEntry>,
+    catalog_index: Option<usize>,
+}
+
+async fn open_local_zip_reader(path: &Path) -> Result<LocalZipReader> {
+    ZipFileReader::new(path)
+        .await
+        .map_err(|err| invalid_local_path(path, format!("cannot open ZIP file: {err}")))
+}
+
+fn local_zip_entries_for_s3(
+    stored_entries: &[StoredZipEntry],
+    destination: &S3Prefix,
+    source_len: u64,
+    enforce_s3_limit: bool,
+) -> Result<LocalZipEntries> {
+    local_zip_entries(stored_entries, source_len, enforce_s3_limit, |zip_path| {
+        destination.join_key(zip_path)
+    })
+}
+
+fn local_zip_entries_for_local(
+    stored_entries: &[StoredZipEntry],
+    source_len: u64,
+    enforce_s3_limit: bool,
+) -> Result<LocalZipEntries> {
+    local_zip_entries(stored_entries, source_len, enforce_s3_limit, str::to_string)
+}
+
+fn local_zip_entries(
+    stored_entries: &[StoredZipEntry],
+    source_len: u64,
+    enforce_s3_limit: bool,
+    destination: impl Fn(&str) -> String,
+) -> Result<LocalZipEntries> {
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+    let mut catalog_index = None;
+
+    for (index, stored) in stored_entries.iter().enumerate() {
+        let raw_path = stored
+            .filename()
+            .as_str()
+            .map_err(|err| Error::InvalidZipEntry {
+                path: format!("{:?}", stored.filename().as_bytes()),
+                reason: err.to_string(),
+            })?;
+        let zip_entry_path = normalize_zip_entry_path(raw_path)?;
+        let zip_path = zip_entry_path.path;
+        let is_directory = zip_entry_path.is_directory;
+
+        if !is_directory && zip_path == EMBEDDED_CATALOG_PATH {
+            catalog_index = Some(index);
+            continue;
+        }
+
+        validate_local_stored_entry(
+            stored,
+            &zip_path,
+            is_directory,
+            enforce_s3_limit,
+            source_len,
+        )?;
+        if !seen.insert(zip_path.clone()) {
+            return Err(Error::DuplicateZipPath(zip_path));
+        }
+
+        entries.push(LocalZipEntry {
+            index,
+            destination: destination(&zip_path),
+            zip_path,
+            size: stored.uncompressed_size(),
+            compressed_size: stored.compressed_size(),
+            compression: stored.compression(),
+            crc32: stored.crc32(),
+            catalog_md5: None,
+            is_directory,
+        });
+    }
+
+    Ok(LocalZipEntries {
+        entries,
+        catalog_index,
+    })
+}
+
+fn validate_local_stored_entry(
+    stored: &StoredZipEntry,
+    zip_path: &str,
+    is_directory: bool,
+    enforce_s3_limit: bool,
+    source_len: u64,
+) -> Result<()> {
+    let source_span_end = stored
+        .header_offset()
+        .checked_add(stored.header_size())
+        .and_then(|offset| offset.checked_add(stored.compressed_size()))
+        .ok_or_else(|| Error::InvalidZipEntry {
+            path: zip_path.to_string(),
+            reason: "central directory entry source span overflowed".to_string(),
+        })?;
+    if source_span_end > source_len {
+        return Err(Error::InvalidZipEntry {
+            path: zip_path.to_string(),
+            reason: format!(
+                "central directory entry source span ends at {source_span_end}, beyond source ZIP length {source_len}"
+            ),
+        });
+    }
+
+    if is_directory {
+        if stored.uncompressed_size() != 0 || stored.compressed_size() != 0 {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: "directory entries must be zero length".to_string(),
+            });
+        }
+        if stored.crc32() != 0 {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: "directory entries must have a zero CRC32".to_string(),
+            });
+        }
+        return Ok(());
+    }
+
+    match stored.compression() {
+        Compression::Stored | Compression::Deflate => {}
+        other => {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: format!("unsupported compression method {other:?}"),
+            });
+        }
+    }
+
+    if enforce_s3_limit && stored.uncompressed_size() > crate::constants::S3_SINGLE_PUT_LIMIT {
+        return Err(Error::EntryTooLarge {
+            path: zip_path.to_string(),
+            size: stored.uncompressed_size(),
+        });
+    }
+
+    Ok(())
+}
+
+async fn load_local_embedded_catalog(
+    reader: &LocalZipReader,
+    catalog_index: Option<usize>,
+) -> HashMap<String, String> {
+    let Some(catalog_index) = catalog_index else {
+        return HashMap::new();
+    };
+    let Some(catalog_entry) = reader.file().entries().get(catalog_index) else {
+        tracing::warn!(catalog_index, "local embedded catalog index is missing");
+        return HashMap::new();
+    };
+    let catalog_size = catalog_entry.uncompressed_size();
+    let catalog_compressed_size = catalog_entry.compressed_size();
+    if catalog_size > EMBEDDED_CATALOG_MAX_BYTES
+        || catalog_compressed_size > EMBEDDED_CATALOG_MAX_BYTES
+    {
+        tracing::warn!(
+            catalog_size,
+            catalog_compressed_size,
+            max_bytes = EMBEDDED_CATALOG_MAX_BYTES,
+            "local embedded catalog exceeded size limit"
+        );
+        return HashMap::new();
+    }
+    let expected_crc32 = catalog_entry.crc32();
+
+    let mut catalog_reader = match reader.reader_without_entry(catalog_index).await {
+        Ok(reader) => reader,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to open local embedded catalog");
+            return HashMap::new();
+        }
+    };
+    let mut catalog_bytes = Vec::new();
+    {
+        let mut limited_reader = futures_lite::io::AsyncReadExt::take(
+            &mut catalog_reader,
+            EMBEDDED_CATALOG_MAX_BYTES + 1,
+        );
+        if let Err(err) =
+            futures_lite::io::AsyncReadExt::read_to_end(&mut limited_reader, &mut catalog_bytes)
+                .await
+        {
+            tracing::warn!(error = %err, "failed to read local embedded catalog");
+            return HashMap::new();
+        }
+    }
+    if catalog_bytes.len() > EMBEDDED_CATALOG_MAX_BYTES as usize {
+        tracing::warn!(
+            read_bytes = catalog_bytes.len(),
+            max_bytes = EMBEDDED_CATALOG_MAX_BYTES,
+            "local embedded catalog exceeded size limit"
+        );
+        return HashMap::new();
+    }
+    if let Err(err) = validate_crc32_value(expected_crc32, catalog_reader.compute_hash()) {
+        tracing::warn!(error = %err, "local embedded catalog CRC validation failed");
+        return HashMap::new();
+    }
+    match serde_json::from_slice::<EmbeddedCatalog>(&catalog_bytes) {
+        Ok(catalog) => catalog_md5_by_path(catalog),
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to parse local embedded catalog");
+            HashMap::new()
+        }
+    }
+}
+
+fn apply_local_catalog(entries: &mut [LocalZipEntry], catalog: HashMap<String, String>) {
+    if catalog.is_empty() {
+        return;
+    }
+    for entry in entries {
+        entry.catalog_md5 = catalog.get(&entry.zip_path).cloned();
+    }
+}
+
+async fn unzip_local_entry_to_s3(
+    client: &Client,
+    reader: &LocalZipReader,
+    entry: LocalZipEntry,
+    destination_objects: &HashMap<String, DestinationObject>,
+    options: &LocalZipSyncOptions,
+) -> ObjectReport {
+    let existing = destination_objects.get(&entry.destination);
+    if entry.is_directory {
+        return put_local_directory_marker(client, entry, existing, options).await;
+    }
+
+    let destination_etag = existing.and_then(|destination| destination.etag.clone());
+    if let (Some(catalog_md5), Some(destination_etag)) =
+        (entry.catalog_md5.as_ref(), destination_etag.as_ref())
+        && normalize_etag(destination_etag).as_ref() == Some(catalog_md5)
+        && existing.and_then(|destination| destination.size) == Some(entry.size)
+    {
+        return ObjectReport {
+            status: OperationStatus::SkippedUnchanged,
+            key: entry.destination,
+            zip_path: Some(entry.zip_path),
+            size: Some(entry.size),
+            md5: Some(catalog_md5.clone()),
+            destination_etag: Some(destination_etag.clone()),
+            message: None,
+        };
+    }
+
+    let entry_reader = match reader.reader_without_entry(entry.index).await {
+        Ok(reader) => reader.compat(),
+        Err(err) => {
+            return local_entry_error(&entry, destination_etag, err.to_string());
+        }
+    };
+
+    if let Some(destination) = existing
+        && let Some(destination_etag) = &destination.etag
+        && let Some(destination_md5) =
+            comparable_destination_md5(destination, destination_etag, &local_manifest_entry(&entry))
+    {
+        match digest_local_reader(entry_reader, &entry).await {
+            Ok(digest) if digest.md5 == destination_md5 => {
+                return ObjectReport {
+                    status: OperationStatus::SkippedUnchanged,
+                    key: entry.destination,
+                    zip_path: Some(entry.zip_path),
+                    size: Some(digest.bytes),
+                    md5: Some(digest.md5),
+                    destination_etag: Some(destination_etag.clone()),
+                    message: None,
+                };
+            }
+            Ok(_) => {}
+            Err(err) => {
+                return local_entry_error(&entry, Some(destination_etag.clone()), err.to_string());
+            }
+        }
+
+        let entry_reader = match reader.reader_without_entry(entry.index).await {
+            Ok(reader) => reader.compat(),
+            Err(err) => {
+                return local_entry_error(&entry, Some(destination_etag.clone()), err.to_string());
+            }
+        };
+        return put_local_file_entry_to_s3(
+            client,
+            entry_reader,
+            entry,
+            PutCondition::IfMatch(destination_etag.clone()),
+            Some(destination_etag.clone()),
+            options,
+        )
+        .await;
+    }
+
+    let condition = destination_etag
+        .clone()
+        .map(PutCondition::IfMatch)
+        .unwrap_or(PutCondition::IfNoneMatch);
+    put_local_file_entry_to_s3(
+        client,
+        entry_reader,
+        entry,
+        condition,
+        destination_etag,
+        options,
+    )
+    .await
+}
+
+async fn put_local_directory_marker(
+    client: &Client,
+    entry: LocalZipEntry,
+    existing: Option<&DestinationObject>,
+    options: &LocalZipSyncOptions,
+) -> ObjectReport {
+    if let Some(existing) = existing {
+        return match existing.size {
+            Some(0) => ObjectReport {
+                status: OperationStatus::SkippedUnchanged,
+                key: entry.destination,
+                zip_path: Some(entry.zip_path),
+                size: Some(0),
+                md5: Some(empty_md5()),
+                destination_etag: existing.etag.clone(),
+                message: None,
+            },
+            Some(size) => local_directory_marker_error(
+                entry,
+                existing.etag.clone(),
+                format!("destination directory marker key exists with nonzero size {size}"),
+            ),
+            None => local_directory_marker_error(
+                entry,
+                existing.etag.clone(),
+                "destination directory marker was listed without a size".to_string(),
+            ),
+        };
+    }
+
+    let mut request = client
+        .put_object()
+        .bucket(&options.destination.bucket)
+        .key(&entry.destination)
+        .content_length(0)
+        .body(ByteStream::from_static(b""));
+    request = request.if_none_match("*");
+    match request.send().await {
+        Ok(_) => ObjectReport {
+            status: OperationStatus::UploadedNew,
+            key: entry.destination,
+            zip_path: Some(entry.zip_path),
+            size: Some(0),
+            md5: Some(empty_md5()),
+            destination_etag: None,
+            message: None,
+        },
+        Err(err) if is_conditional_put_conflict(&err) => ObjectReport {
+            status: OperationStatus::ConditionalConflict,
+            key: entry.destination,
+            zip_path: Some(entry.zip_path),
+            size: Some(0),
+            md5: Some(empty_md5()),
+            destination_etag: None,
+            message: Some(aws_error_context(&err)),
+        },
+        Err(err) => ObjectReport {
+            status: OperationStatus::Error,
+            key: entry.destination,
+            zip_path: Some(entry.zip_path),
+            size: Some(0),
+            md5: None,
+            destination_etag: None,
+            message: Some(aws_error_context(&err)),
+        },
+    }
+}
+
+fn local_directory_marker_error(
+    entry: LocalZipEntry,
+    destination_etag: Option<String>,
+    message: String,
+) -> ObjectReport {
+    ObjectReport {
+        status: OperationStatus::Error,
+        key: entry.destination,
+        zip_path: Some(entry.zip_path),
+        size: Some(0),
+        md5: None,
+        destination_etag,
+        message: Some(message),
+    }
+}
+
+async fn put_local_file_entry_to_s3<R>(
+    client: &Client,
+    entry_reader: R,
+    entry: LocalZipEntry,
+    condition: PutCondition,
+    destination_etag: Option<String>,
+    options: &LocalZipSyncOptions,
+) -> ObjectReport
+where
+    R: AsyncRead + Send + Unpin + 'static,
+{
+    if entry.size == 0 {
+        let digest = match digest_local_reader(entry_reader, &entry).await {
+            Ok(digest) => digest,
+            Err(err) => return local_entry_error(&entry, destination_etag, err.to_string()),
+        };
+        let mut request = client
+            .put_object()
+            .bucket(&options.destination.bucket)
+            .key(&entry.destination)
+            .content_length(0)
+            .body(ByteStream::from_static(b""));
+        request = match &condition {
+            PutCondition::IfNoneMatch => request.if_none_match("*"),
+            PutCondition::IfMatch(etag) => request.if_match(etag),
+        };
+
+        return match request.send().await {
+            Ok(_) => ObjectReport {
+                status: if destination_etag.is_some() {
+                    OperationStatus::UploadedChanged
+                } else {
+                    OperationStatus::UploadedNew
+                },
+                key: entry.destination,
+                zip_path: Some(entry.zip_path),
+                size: Some(digest.bytes),
+                md5: Some(digest.md5),
+                destination_etag,
+                message: None,
+            },
+            Err(err) if is_conditional_put_conflict(&err) => ObjectReport {
+                status: OperationStatus::ConditionalConflict,
+                key: entry.destination,
+                zip_path: Some(entry.zip_path),
+                size: Some(entry.size),
+                md5: Some(digest.md5),
+                destination_etag,
+                message: Some(aws_error_context(&err)),
+            },
+            Err(err) => local_entry_error(&entry, destination_etag, aws_error_context(&err)),
+        };
+    }
+
+    let (writer, reader) = tokio::io::duplex(options.pipe_capacity);
+    let producer_entry = entry.clone();
+    let mut producer = AbortOnDropJoinHandle::new(tokio::spawn(async move {
+        write_local_entry_to_pipe(writer, entry_reader, producer_entry).await
+    }));
+
+    let stream = ReaderStream::with_capacity(reader, options.body_chunk_size).map_ok(Frame::data);
+    let body = ByteStream::new(SdkBody::from_body_1_x(StreamBody::new(stream)));
+    let content_length = match i64::try_from(entry.size) {
+        Ok(length) => length,
+        Err(_) => {
+            producer.abort();
+            return local_entry_error(
+                &entry,
+                destination_etag,
+                "entry size does not fit S3 content length".to_string(),
+            );
+        }
+    };
+    let mut request = client
+        .put_object()
+        .bucket(&options.destination.bucket)
+        .key(&entry.destination)
+        .content_length(content_length)
+        .body(body);
+    request = match &condition {
+        PutCondition::IfNoneMatch => request.if_none_match("*"),
+        PutCondition::IfMatch(etag) => request.if_match(etag),
+    };
+
+    match request.send().await {
+        Ok(_) => match producer.join().await {
+            Ok(Ok(digest)) => ObjectReport {
+                status: if destination_etag.is_some() {
+                    OperationStatus::UploadedChanged
+                } else {
+                    OperationStatus::UploadedNew
+                },
+                key: entry.destination,
+                zip_path: Some(entry.zip_path),
+                size: Some(digest.bytes),
+                md5: Some(digest.md5),
+                destination_etag,
+                message: None,
+            },
+            Ok(Err(err)) => local_entry_error(&entry, destination_etag, err.to_string()),
+            Err(err) => local_entry_error(&entry, destination_etag, err.to_string()),
+        },
+        Err(err) if is_conditional_put_conflict(&err) => {
+            producer.abort();
+            let _ = producer.join().await;
+            ObjectReport {
+                status: OperationStatus::ConditionalConflict,
+                key: entry.destination,
+                zip_path: Some(entry.zip_path),
+                size: Some(entry.size),
+                md5: entry.catalog_md5,
+                destination_etag,
+                message: Some(aws_error_context(&err)),
+            }
+        }
+        Err(err) => {
+            producer.abort();
+            let _ = producer.join().await;
+            local_entry_error(&entry, destination_etag, aws_error_context(&err))
+        }
+    }
+}
+
+async fn unzip_local_entry_to_local(
+    reader: &LocalZipReader,
+    entry: LocalZipEntry,
+    destination_root: &Path,
+) -> ObjectReport {
+    if entry.is_directory {
+        return create_local_directory_entry(destination_root, &entry).await;
+    }
+
+    let existed = local_destination_exists(destination_root, &entry).await;
+    let entry_reader = match reader.reader_without_entry(entry.index).await {
+        Ok(reader) => reader.compat(),
+        Err(err) => {
+            return local_destination_error(destination_root, &entry, err.to_string());
+        }
+    };
+    write_reader_to_local_destination(destination_root, &entry, entry_reader, existed).await
+}
+
+async fn unzip_s3_entry_to_local(
+    store: Arc<BlockStore>,
+    entry: ManifestEntry,
+    destination_root: PathBuf,
+) -> ObjectReport {
+    let local_entry = local_entry_from_manifest(&entry);
+    if entry.is_directory {
+        return create_local_directory_entry(&destination_root, &local_entry).await;
+    }
+
+    let existed = local_destination_exists(&destination_root, &local_entry).await;
+    let reader = match entry_reader(store, &entry).await {
+        Ok(reader) => reader,
+        Err(err) => {
+            return local_destination_error(&destination_root, &local_entry, err.to_string());
+        }
+    };
+    write_reader_to_local_destination(&destination_root, &local_entry, reader, existed).await
+}
+
+async fn create_local_directory_entry(
+    destination_root: &Path,
+    entry: &LocalZipEntry,
+) -> ObjectReport {
+    let destination = local_destination_path(destination_root, &entry.zip_path);
+    let existed = path_is_directory(&destination).await;
+    let result = create_directory_no_symlink(destination_root, &entry.zip_path).await;
+    match result {
+        Ok(()) => ObjectReport {
+            status: if existed {
+                OperationStatus::SkippedUnchanged
+            } else {
+                OperationStatus::UploadedNew
+            },
+            key: destination.display().to_string(),
+            zip_path: Some(entry.zip_path.clone()),
+            size: Some(0),
+            md5: Some(empty_md5()),
+            destination_etag: None,
+            message: None,
+        },
+        Err(err) => local_destination_error(destination_root, entry, err.to_string()),
+    }
+}
+
+async fn write_reader_to_local_destination<R>(
+    destination_root: &Path,
+    entry: &LocalZipEntry,
+    reader: R,
+    existed: bool,
+) -> ObjectReport
+where
+    R: AsyncRead + Unpin,
+{
+    let destination = local_destination_path(destination_root, &entry.zip_path);
+    let result = async {
+        create_parent_dirs_for_file(destination_root, &entry.zip_path).await?;
+        reject_existing_symlink_or_directory(&destination).await?;
+        let temp_path = temp_sibling_path(&destination)?;
+        let file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .await
+            .map_err(|err| invalid_local_path(&temp_path, format!("cannot create file: {err}")))?;
+        let digest = match write_local_entry_to_file(file, reader, entry).await {
+            Ok(digest) => digest,
+            Err(err) => {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                return Err(err);
+            }
+        };
+        replace_temp_file(&temp_path, &destination, "completed file").await?;
+        Ok(digest)
+    }
+    .await;
+
+    match result {
+        Ok(digest) => ObjectReport {
+            status: if existed {
+                OperationStatus::UploadedChanged
+            } else {
+                OperationStatus::UploadedNew
+            },
+            key: destination.display().to_string(),
+            zip_path: Some(entry.zip_path.clone()),
+            size: Some(digest.bytes),
+            md5: Some(digest.md5),
+            destination_etag: None,
+            message: None,
+        },
+        Err(err) => local_destination_error(destination_root, entry, err.to_string()),
+    }
+}
+
+async fn write_local_entry_to_pipe<R>(
+    writer: DuplexStream,
+    reader: R,
+    entry: LocalZipEntry,
+) -> Result<ExtractDigest>
+where
+    R: AsyncRead + Unpin,
+{
+    write_local_entry_to_writer(writer, reader, &entry).await
+}
+
+async fn write_local_entry_to_file<R>(
+    file: tokio::fs::File,
+    reader: R,
+    entry: &LocalZipEntry,
+) -> Result<ExtractDigest>
+where
+    R: AsyncRead + Unpin,
+{
+    write_local_entry_to_writer(file, reader, entry).await
+}
+
+async fn write_local_entry_to_writer<W, R>(
+    mut writer: W,
+    mut reader: R,
+    entry: &LocalZipEntry,
+) -> Result<ExtractDigest>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+{
+    let mut hasher = Md5::new();
+    let mut crc32 = Crc32Hasher::new();
+    let mut bytes = 0_u64;
+    const BUFFER_SIZE: usize = 64 * 1024;
+    let mut buffer = vec![0_u8; BUFFER_SIZE];
+    let mut pending = vec![0_u8; BUFFER_SIZE];
+    let mut pending_len = 0;
+
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        let next_bytes = bytes.saturating_add(read as u64);
+        validate_local_extracted_size_not_exceeded(entry, next_bytes)?;
+        if pending_len != 0 {
+            writer.write_all(&pending[..pending_len]).await?;
+        }
+        hasher.update(&buffer[..read]);
+        crc32.update(&buffer[..read]);
+        std::mem::swap(&mut pending, &mut buffer);
+        pending_len = read;
+        bytes = next_bytes;
+    }
+
+    validate_local_extracted_size(entry, bytes)?;
+    validate_crc32_value(entry.crc32, crc32.finalize())?;
+    if pending_len != 0 {
+        writer.write_all(&pending[..pending_len]).await?;
+    }
+    writer.shutdown().await?;
+    Ok(ExtractDigest {
+        bytes,
+        md5: hex::encode(hasher.finalize()),
+    })
+}
+
+async fn digest_local_reader<R>(reader: R, entry: &LocalZipEntry) -> Result<ExtractDigest>
+where
+    R: AsyncRead + Unpin,
+{
+    write_local_entry_to_writer(tokio::io::sink(), reader, entry).await
+}
+
+fn validate_local_extracted_size(entry: &LocalZipEntry, bytes: u64) -> Result<()> {
+    if bytes == entry.size {
+        Ok(())
+    } else {
+        Err(Error::InvalidZipEntry {
+            path: entry.zip_path.clone(),
+            reason: format!(
+                "entry produced {bytes} bytes but central directory declared {} bytes",
+                entry.size
+            ),
+        })
+    }
+}
+
+fn validate_local_extracted_size_not_exceeded(entry: &LocalZipEntry, bytes: u64) -> Result<()> {
+    if bytes <= entry.size {
+        Ok(())
+    } else {
+        validate_local_extracted_size(entry, bytes)
+    }
+}
+
+fn local_entry_error(
+    entry: &LocalZipEntry,
+    destination_etag: Option<String>,
+    message: String,
+) -> ObjectReport {
+    ObjectReport {
+        status: OperationStatus::Error,
+        key: entry.destination.clone(),
+        zip_path: Some(entry.zip_path.clone()),
+        size: Some(entry.size),
+        md5: entry.catalog_md5.clone(),
+        destination_etag,
+        message: Some(message),
+    }
+}
+
+fn local_destination_error(
+    destination_root: &Path,
+    entry: &LocalZipEntry,
+    message: String,
+) -> ObjectReport {
+    ObjectReport {
+        status: OperationStatus::Error,
+        key: local_destination_path(destination_root, &entry.zip_path)
+            .display()
+            .to_string(),
+        zip_path: Some(entry.zip_path.clone()),
+        size: Some(entry.size),
+        md5: entry.catalog_md5.clone(),
+        destination_etag: None,
+        message: Some(message),
+    }
+}
+
+fn local_entry_from_manifest(entry: &ManifestEntry) -> LocalZipEntry {
+    LocalZipEntry {
+        index: 0,
+        zip_path: entry.zip_path.clone(),
+        destination: entry.zip_path.clone(),
+        size: entry.size,
+        compressed_size: entry.compressed_size,
+        compression: entry.compression,
+        crc32: entry.crc32,
+        catalog_md5: entry.catalog_md5.clone(),
+        is_directory: entry.is_directory,
+    }
+}
+
+fn local_manifest_entry(entry: &LocalZipEntry) -> ManifestEntry {
+    ManifestEntry {
+        source_offset: 0,
+        source_span_start: 0,
+        source_span_end: entry.compressed_size,
+        zip_path: entry.zip_path.clone(),
+        key: entry.destination.clone(),
+        size: entry.size,
+        compressed_size: entry.compressed_size,
+        compression: entry.compression,
+        crc32: entry.crc32,
+        catalog_md5: entry.catalog_md5.clone(),
+        is_directory: entry.is_directory,
+    }
+}
+
+async fn prepare_local_destination_root(destination: &Path) -> Result<PathBuf> {
+    create_destination_directory_no_symlink(destination).await?;
+    Ok(destination.to_path_buf())
+}
+
+async fn destination_uses_case_insensitive_paths(root: &Path) -> Result<bool> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let probe_name = format!(".s3-unspool-case-probe-{}-{nanos}-a", std::process::id());
+    let probe_path = root.join(&probe_name);
+    let alternate_path = root.join(probe_name.to_ascii_uppercase());
+
+    let file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+        .await
+        .map_err(|err| {
+            invalid_local_path(
+                &probe_path,
+                format!("cannot create case-sensitivity probe: {err}"),
+            )
+        })?;
+    drop(file);
+
+    let result = match tokio::fs::symlink_metadata(&alternate_path).await {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(invalid_local_path(
+            &alternate_path,
+            format!("cannot inspect case-sensitivity probe: {err}"),
+        )),
+    };
+    let cleanup = tokio::fs::remove_file(&probe_path).await;
+
+    match (result, cleanup) {
+        (Ok(case_insensitive), Ok(())) => Ok(case_insensitive),
+        (Ok(case_insensitive), Err(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(case_insensitive)
+        }
+        (Ok(_), Err(err)) => Err(invalid_local_path(
+            &probe_path,
+            format!("cannot remove case-sensitivity probe: {err}"),
+        )),
+        (Err(err), _) => Err(err),
+    }
+}
+
+async fn create_destination_directory_no_symlink(destination: &Path) -> Result<()> {
+    match tokio::fs::symlink_metadata(destination).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(invalid_local_path(
+                destination,
+                "destination directory cannot be a symbolic link".to_string(),
+            ));
+        }
+        Ok(metadata) if metadata.is_dir() => return Ok(()),
+        Ok(_) => {
+            return Err(invalid_local_path(
+                destination,
+                "destination must be a directory".to_string(),
+            ));
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(invalid_local_path(
+                destination,
+                format!("cannot inspect destination directory: {err}"),
+            ));
+        }
+    }
+
+    let mut missing = vec![destination.to_path_buf()];
+    let mut current = destination;
+    while let Some(parent) = current.parent() {
+        if parent.as_os_str().is_empty() {
+            break;
+        }
+
+        match tokio::fs::symlink_metadata(parent).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(invalid_local_path(
+                    parent,
+                    "destination path component cannot be a symbolic link".to_string(),
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => break,
+            Ok(_) => {
+                return Err(invalid_local_path(
+                    parent,
+                    "destination path component exists and is not a directory".to_string(),
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(parent.to_path_buf());
+                current = parent;
+            }
+            Err(err) => {
+                return Err(invalid_local_path(
+                    parent,
+                    format!("cannot inspect destination path component: {err}"),
+                ));
+            }
+        }
+    }
+
+    for path in missing.into_iter().rev() {
+        ensure_directory_component(&path).await?;
+    }
+
+    Ok(())
+}
+
+fn local_destination_path(root: &Path, zip_path: &str) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for component in zip_path.trim_end_matches('/').split('/') {
+        if !component.is_empty() {
+            path.push(component);
+        }
+    }
+    path
+}
+
+fn validate_local_destination_path_collisions<'a>(
+    entries: impl IntoIterator<Item = (&'a str, bool)>,
+    case_insensitive: bool,
+) -> Result<()> {
+    let mut destinations = HashMap::<String, (String, bool)>::new();
+    for (zip_path, is_directory) in entries {
+        let local_path = zip_path.trim_end_matches('/').to_string();
+        let destination_key = normalize_local_collision_key(&local_path, case_insensitive);
+        if let Some((previous, _)) =
+            destinations.insert(destination_key, (zip_path.to_string(), is_directory))
+        {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: format!(
+                    "maps to the same local destination path as ZIP entry `{previous}`"
+                ),
+            });
+        }
+    }
+
+    let file_destinations = destinations
+        .iter()
+        .filter(|(_, (_, is_directory))| !is_directory)
+        .map(|(local_path, (zip_path, _))| (local_path.as_str(), zip_path.as_str()))
+        .collect::<HashMap<_, _>>();
+    for (local_path, (zip_path, _)) in &destinations {
+        let mut ancestor = String::new();
+        let mut components = local_path.split('/').peekable();
+        while let Some(component) = components.next() {
+            if components.peek().is_none() {
+                break;
+            }
+            if !ancestor.is_empty() {
+                ancestor.push('/');
+            }
+            ancestor.push_str(component);
+            if let Some(file_zip_path) = file_destinations.get(ancestor.as_str()) {
+                return Err(Error::InvalidZipEntry {
+                    path: zip_path.clone(),
+                    reason: format!(
+                        "maps under the same local destination path as file ZIP entry `{file_zip_path}`"
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_local_destination_zip_paths<'a>(
+    zip_paths: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    for zip_path in zip_paths {
+        for component in zip_path.trim_end_matches('/').split('/') {
+            validate_local_destination_component(zip_path, component)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_local_destination_component(zip_path: &str, component: &str) -> Result<()> {
+    let has_windows_reserved_character = component
+        .chars()
+        .any(|character| matches!(character, '<' | '>' | ':' | '"' | '|' | '?' | '*'));
+    let has_control_character = component.chars().any(|character| character.is_control());
+    let has_reserved_suffix = component.ends_with([' ', '.']);
+    let stem = component
+        .split_once('.')
+        .map(|(stem, _)| stem)
+        .unwrap_or(component)
+        .trim_end_matches([' ', '.']);
+    let upper_stem = stem.to_ascii_uppercase();
+    let is_reserved_device_name = matches!(
+        upper_stem.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" | "CONIN$" | "CONOUT$"
+    ) || is_numbered_windows_device_name(&upper_stem, "COM")
+        || is_numbered_windows_device_name(&upper_stem, "LPT");
+
+    if has_windows_reserved_character
+        || has_control_character
+        || has_reserved_suffix
+        || is_reserved_device_name
+    {
+        Err(Error::InvalidZipEntry {
+            path: zip_path.to_string(),
+            reason: format!("unsafe local path component `{component}`"),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn is_numbered_windows_device_name(value: &str, prefix: &str) -> bool {
+    let Some(suffix) = value.strip_prefix(prefix) else {
+        return false;
+    };
+    matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+}
+
+fn normalize_local_collision_key(path: &str, case_insensitive: bool) -> String {
+    if case_insensitive {
+        path.to_lowercase()
+    } else {
+        path.to_string()
+    }
+}
+
+async fn reject_local_unzip_source_archive_target(
+    source_zip: &Path,
+    destination_root: &Path,
+    entries: &[LocalZipEntry],
+) -> Result<()> {
+    let source_zip = tokio::fs::canonicalize(source_zip).await.map_err(|err| {
+        invalid_local_path(source_zip, format!("cannot inspect source ZIP: {err}"))
+    })?;
+
+    for entry in entries {
+        let destination = local_destination_path(destination_root, &entry.zip_path);
+        match tokio::fs::canonicalize(&destination).await {
+            Ok(destination) if destination == source_zip => {
+                return Err(invalid_local_path(
+                    &destination,
+                    format!(
+                        "ZIP entry `{}` would overwrite the source archive {}",
+                        entry.zip_path,
+                        source_zip.display()
+                    ),
+                ));
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(invalid_local_path(
+                    &destination,
+                    format!("cannot inspect destination path: {err}"),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn local_destination_exists(root: &Path, entry: &LocalZipEntry) -> bool {
+    tokio::fs::symlink_metadata(local_destination_path(root, &entry.zip_path))
+        .await
+        .is_ok()
+}
+
+async fn path_is_directory(path: &Path) -> bool {
+    tokio::fs::symlink_metadata(path)
+        .await
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+}
+
+async fn create_directory_no_symlink(root: &Path, zip_path: &str) -> Result<()> {
+    let mut current = root.to_path_buf();
+    for component in zip_path.trim_end_matches('/').split('/') {
+        if component.is_empty() {
+            continue;
+        }
+        current.push(component);
+        ensure_directory_component(&current).await?;
+    }
+    Ok(())
+}
+
+async fn create_parent_dirs_for_file(root: &Path, zip_path: &str) -> Result<()> {
+    let Some((parent, _file_name)) = zip_path.rsplit_once('/') else {
+        return Ok(());
+    };
+    create_directory_no_symlink(root, parent).await
+}
+
+async fn ensure_directory_component(path: &Path) -> Result<()> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_local_path(
+            path,
+            "destination path component cannot be a symbolic link".to_string(),
+        )),
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(invalid_local_path(
+            path,
+            "destination path component exists and is not a directory".to_string(),
+        )),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            create_directory_component(path).await
+        }
+        Err(err) => Err(invalid_local_path(
+            path,
+            format!("cannot inspect destination path component: {err}"),
+        )),
+    }
+}
+
+async fn create_directory_component(path: &Path) -> Result<()> {
+    match tokio::fs::create_dir(path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            match tokio::fs::symlink_metadata(path).await {
+                Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_local_path(
+                    path,
+                    "destination path component cannot be a symbolic link".to_string(),
+                )),
+                Ok(metadata) if metadata.is_dir() => Ok(()),
+                Ok(_) => Err(invalid_local_path(
+                    path,
+                    "destination path component exists and is not a directory".to_string(),
+                )),
+                Err(err) => Err(invalid_local_path(
+                    path,
+                    format!("cannot inspect destination path component after create race: {err}"),
+                )),
+            }
+        }
+        Err(err) => Err(invalid_local_path(
+            path,
+            format!("cannot create directory: {err}"),
+        )),
+    }
+}
+
+async fn reject_existing_symlink_or_directory(path: &Path) -> Result<()> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_local_path(
+            path,
+            "destination file cannot be a symbolic link".to_string(),
+        )),
+        Ok(metadata) if metadata.is_dir() => Err(invalid_local_path(
+            path,
+            "destination file path is a directory".to_string(),
+        )),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(invalid_local_path(
+            path,
+            format!("cannot inspect destination file: {err}"),
+        )),
+    }
+}
+
+fn validate_local_zip_sync_options(options: &LocalZipSyncOptions) -> Result<()> {
+    validate_upload_stream_options(options.body_chunk_size, options.pipe_capacity)?;
+    if options.delete_extra && options.destination.prefix.is_empty() {
+        return Err(Error::InvalidOption(
+            "delete_extra requires a non-empty destination prefix".to_string(),
+        ));
+    }
+    if options.concurrency == 0 {
+        return Err(Error::InvalidOption(
+            "concurrency must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_local_unzip_options(options: &LocalUnzipOptions) -> Result<()> {
+    if options.concurrency == 0 {
+        return Err(Error::InvalidOption(
+            "concurrency must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_s3_zip_local_unzip_options(options: &S3ZipLocalUnzipOptions) -> Result<()> {
+    if options.concurrency == 0 {
+        return Err(Error::InvalidOption(
+            "concurrency must be greater than zero".to_string(),
+        ));
+    }
+    if options.source_get_concurrency == 0 {
+        return Err(Error::InvalidOption(
+            "source_get_concurrency must be greater than zero".to_string(),
+        ));
+    }
+    if options.source_block_size == 0 {
+        return Err(Error::InvalidOption(
+            "source_block_size must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_s3_zip_local_source_range_options(
+    options: &S3ZipLocalUnzipOptions,
+    source_len: u64,
+) -> Result<()> {
+    let mut sync = local_unzip_source_sync_options(options);
+    sync.source_window_capacity = options.source_window_capacity;
+    validate_source_range_options(&sync, source_len)
+}
+
+fn resolve_s3_zip_local_window_capacity(
+    options: &mut S3ZipLocalUnzipOptions,
+    source_zip_bytes: u64,
+    zip_file_count: usize,
+) {
+    if let Some(memory_mb) = options.source_window_memory_budget_mb {
+        options.source_window_capacity = adaptive_source_window_capacity(
+            memory_mb,
+            source_zip_bytes,
+            options.concurrency,
+            zip_file_count,
+            options.source_block_size,
+            options.source_get_concurrency,
+        );
+    }
+}
+
+fn local_unzip_source_sync_options(options: &S3ZipLocalUnzipOptions) -> SyncOptions {
+    let mut sync = SyncOptions::new(
+        options.source.clone(),
+        S3Prefix {
+            bucket: "__local__".to_string(),
+            prefix: String::new(),
+        },
+    );
+    sync.collect_diagnostics = options.collect_diagnostics;
+    sync.ignore_embedded_catalog = options.ignore_embedded_catalog;
+    sync.collect_operations = options.collect_operations;
+    sync.concurrency = options.concurrency;
+    sync.source_block_size = options.source_block_size;
+    sync.source_block_merge_gap = options.source_block_merge_gap;
+    sync.source_get_concurrency = options.source_get_concurrency;
+    sync.source_window_capacity = options.source_window_capacity;
+    sync.source_window_memory_budget_mb = options.source_window_memory_budget_mb;
+    sync
+}
+
+fn validate_upload_stream_options(body_chunk_size: usize, pipe_capacity: usize) -> Result<()> {
+    if body_chunk_size == 0 {
+        return Err(Error::InvalidOption(
+            "body_chunk_size must be greater than zero".to_string(),
+        ));
+    }
+    if body_chunk_size > MAX_BODY_CHUNK_SIZE {
+        return Err(Error::InvalidOption(format!(
+            "body_chunk_size must be less than or equal to {MAX_BODY_CHUNK_SIZE}"
+        )));
+    }
+    if pipe_capacity == 0 {
+        return Err(Error::InvalidOption(
+            "pipe_capacity must be greater than zero".to_string(),
+        ));
+    }
+    if pipe_capacity > MAX_PIPE_CAPACITY {
+        return Err(Error::InvalidOption(format!(
+            "pipe_capacity must be less than or equal to {MAX_PIPE_CAPACITY}"
+        )));
+    }
+    Ok(())
+}
+
 fn log_operation_issue(operation: &ObjectReport, progress: &ExtractProgress) {
     match operation.status {
         OperationStatus::Error => {
@@ -800,6 +2339,11 @@ fn classify_entries(
 
     for entry in entries {
         let existing = destination_objects.get(&entry.key);
+        if entry.is_directory {
+            classify_directory_entry(entry, existing, &mut classified);
+            continue;
+        }
+
         if let Some(report) = catalog_skip_report(&entry, existing) {
             classified.reports.push(report);
             continue;
@@ -850,6 +2394,43 @@ fn classify_entries(
     }
 
     classified
+}
+
+fn classify_directory_entry(
+    entry: ManifestEntry,
+    existing: Option<&DestinationObject>,
+    classified: &mut ClassifiedEntries,
+) {
+    let Some(destination) = existing else {
+        classified.upload_jobs.push(UploadJob {
+            entry,
+            condition: PutCondition::IfNoneMatch,
+            comparison_digest: None,
+        });
+        return;
+    };
+
+    match destination.size {
+        Some(0) => classified.reports.push(ObjectReport {
+            status: OperationStatus::SkippedUnchanged,
+            key: entry.key,
+            zip_path: Some(entry.zip_path),
+            size: Some(0),
+            md5: Some(empty_md5()),
+            destination_etag: destination.etag.clone(),
+            message: None,
+        }),
+        Some(size) => classified.reports.push(entry_error(
+            &entry,
+            destination.etag.clone(),
+            format!("destination directory marker key exists with nonzero size {size}"),
+        )),
+        None => classified.reports.push(entry_error(
+            &entry,
+            destination.etag.clone(),
+            "destination directory marker was listed without a size".to_string(),
+        )),
+    }
 }
 
 async fn run_hash_phase(
@@ -1294,6 +2875,10 @@ async fn put_entry_stream_once(
     options: &SyncOptions,
     put_diagnostics: Option<&PutDiagnosticsCollector>,
 ) -> PutAttemptResult {
+    if entry.is_directory {
+        return put_directory_marker_once(client, entry, condition, options, put_diagnostics).await;
+    }
+
     if entry.size == 0 {
         return put_zero_length_entry_once(
             client,
@@ -1392,6 +2977,46 @@ async fn put_entry_stream_once(
     }
 }
 
+async fn put_directory_marker_once(
+    client: &Client,
+    entry: &ManifestEntry,
+    condition: &PutCondition,
+    options: &SyncOptions,
+    put_diagnostics: Option<&PutDiagnosticsCollector>,
+) -> PutAttemptResult {
+    let mut request = client
+        .put_object()
+        .bucket(&options.destination.bucket)
+        .key(&entry.key)
+        .content_length(0)
+        .body(ByteStream::from_static(b""));
+
+    request = match condition {
+        PutCondition::IfNoneMatch => request.if_none_match("*"),
+        PutCondition::IfMatch(etag) => request.if_match(etag.as_str()),
+    };
+
+    match request.send().await {
+        Ok(_) => PutAttemptResult::Uploaded(ExtractDigest {
+            bytes: 0,
+            md5: empty_md5(),
+        }),
+        Err(err) if is_conditional_put_conflict(&err) => {
+            record_put_failure(put_diagnostics, &err);
+            PutAttemptResult::ConditionalConflict(aws_error_context(&err))
+        }
+        Err(err) => {
+            let (error_code, failure_count) = record_put_failure(put_diagnostics, &err);
+            PutAttemptResult::Failed {
+                message: format!("{}: {}", put_sdk_error_kind(&err), aws_error_context(&err)),
+                retryable: true,
+                error_code: Some(error_code),
+                failure_count,
+            }
+        }
+    }
+}
+
 async fn put_zero_length_entry_once(
     client: &Client,
     store: Arc<BlockStore>,
@@ -1440,6 +3065,10 @@ async fn put_zero_length_entry_once(
             }
         }
     }
+}
+
+fn empty_md5() -> String {
+    "d41d8cd98f00b204e9800998ecf8427e".to_string()
 }
 
 fn record_put_failure(
@@ -1904,8 +3533,102 @@ mod tests {
     use async_zip::Compression;
     use aws_sdk_s3::config::{Credentials, Region};
 
-    use crate::S3Object;
     use crate::range::{SourcePlan, SourceRange};
+    use crate::{S3Object, S3Prefix};
+
+    #[test]
+    fn classify_directory_markers_for_preserved_s3_placeholders() {
+        let entry = ManifestEntry {
+            source_offset: 0,
+            source_span_start: 0,
+            source_span_end: 0,
+            zip_path: "empty/".to_string(),
+            key: "prefix/empty/".to_string(),
+            size: 0,
+            compressed_size: 0,
+            compression: Compression::Stored,
+            crc32: 0,
+            catalog_md5: None,
+            is_directory: true,
+        };
+
+        let classified = classify_entries(vec![entry.clone()], &std::collections::HashMap::new());
+        assert_eq!(classified.upload_jobs.len(), 1);
+        assert!(classified.reports.is_empty());
+
+        let destination_objects = std::collections::HashMap::from([(
+            entry.key.clone(),
+            DestinationObject {
+                etag: Some("\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()),
+                size: Some(0),
+            },
+        )]);
+        let classified = classify_entries(vec![entry.clone()], &destination_objects);
+        assert!(classified.upload_jobs.is_empty());
+        assert_eq!(classified.reports.len(), 1);
+        assert_eq!(
+            classified.reports[0].status,
+            OperationStatus::SkippedUnchanged
+        );
+
+        let destination_objects = std::collections::HashMap::from([(
+            entry.key.clone(),
+            DestinationObject {
+                etag: Some("\"etag\"".to_string()),
+                size: Some(1),
+            },
+        )]);
+        let classified = classify_entries(vec![entry], &destination_objects);
+        assert!(classified.upload_jobs.is_empty());
+        assert_eq!(classified.reports.len(), 1);
+        assert_eq!(classified.reports[0].status, OperationStatus::Error);
+    }
+
+    #[tokio::test]
+    async fn local_zip_directory_marker_rejects_nonzero_existing_destination() {
+        let entry = local_directory_entry("prefix/empty/");
+        let existing = DestinationObject {
+            etag: Some("\"etag\"".to_string()),
+            size: Some(1),
+        };
+        let options = LocalZipSyncOptions::new(
+            PathBuf::from("site.zip"),
+            S3Prefix::parse("s3://destination-bucket/prefix/").unwrap(),
+        );
+
+        let report =
+            put_local_directory_marker(&dummy_s3_client(), entry, Some(&existing), &options).await;
+
+        assert_eq!(report.status, OperationStatus::Error);
+        assert_eq!(report.destination_etag.as_deref(), Some("\"etag\""));
+        assert!(matches!(
+            report.message.as_deref(),
+            Some(message) if message.contains("nonzero size 1")
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_zip_directory_marker_rejects_unknown_size_existing_destination() {
+        let entry = local_directory_entry("prefix/empty/");
+        let existing = DestinationObject {
+            etag: Some("\"etag\"".to_string()),
+            size: None,
+        };
+        let options = LocalZipSyncOptions::new(
+            PathBuf::from("site.zip"),
+            S3Prefix::parse("s3://destination-bucket/prefix/").unwrap(),
+        );
+
+        let report =
+            put_local_directory_marker(&dummy_s3_client(), entry, Some(&existing), &options).await;
+
+        assert_eq!(report.status, OperationStatus::Error);
+        assert_eq!(report.destination_etag.as_deref(), Some("\"etag\""));
+        assert!(matches!(
+            report.message.as_deref(),
+            Some(message) if message.contains("without a size")
+        ));
+    }
 
     #[tokio::test]
     async fn producer_error_after_send_error_is_preserved() {
@@ -1975,6 +3698,7 @@ mod tests {
             compression: Compression::Stored,
             crc32: 1,
             catalog_md5: None,
+            is_directory: false,
         };
         let store = zero_length_entry_store(&entry);
         let options = SyncOptions::new(
@@ -2010,6 +3734,228 @@ mod tests {
             }
             _ => panic!("expected zero-byte CRC mismatch to fail before PutObject"),
         }
+    }
+
+    #[tokio::test]
+    async fn local_entry_crc_mismatch_leaves_pipe_short() {
+        let data = (0..(64 * 1024 + 17))
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        let mut crc32 = Crc32Hasher::new();
+        crc32.update(&data);
+        let bad_crc32 = crc32.finalize() ^ u32::MAX;
+        let entry = LocalZipEntry {
+            index: 0,
+            zip_path: "bad.txt".to_string(),
+            destination: "prefix/bad.txt".to_string(),
+            size: data.len() as u64,
+            compressed_size: data.len() as u64,
+            compression: Compression::Stored,
+            crc32: bad_crc32,
+            catalog_md5: None,
+            is_directory: false,
+        };
+        let (writer, mut reader) = tokio::io::duplex(128 * 1024);
+        let producer = tokio::spawn(write_local_entry_to_pipe(
+            writer,
+            std::io::Cursor::new(data.clone()),
+            entry,
+        ));
+        let mut body = Vec::new();
+
+        let read = tokio::time::timeout(Duration::from_secs(1), reader.read_to_end(&mut body))
+            .await
+            .expect("pipe should close after CRC failure")
+            .unwrap();
+        let result = producer.await.unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("CRC"));
+        assert_eq!(read, 64 * 1024);
+        assert_eq!(body, data[..body.len()]);
+        assert!(body.len() < data.len());
+    }
+
+    #[tokio::test]
+    async fn local_entry_size_overflow_leaves_pipe_short() {
+        let data = vec![7_u8; 64 * 1024 + 1];
+        let mut crc32 = Crc32Hasher::new();
+        crc32.update(&data);
+        let entry = LocalZipEntry {
+            index: 0,
+            zip_path: "too-large.txt".to_string(),
+            destination: "prefix/too-large.txt".to_string(),
+            size: 64 * 1024,
+            compressed_size: data.len() as u64,
+            compression: Compression::Stored,
+            crc32: crc32.finalize(),
+            catalog_md5: None,
+            is_directory: false,
+        };
+        let (writer, mut reader) = tokio::io::duplex(128 * 1024);
+        let producer = tokio::spawn(write_local_entry_to_pipe(
+            writer,
+            std::io::Cursor::new(data),
+            entry,
+        ));
+        let mut body = Vec::new();
+
+        let read = tokio::time::timeout(Duration::from_secs(1), reader.read_to_end(&mut body))
+            .await
+            .expect("pipe should close after size overflow")
+            .unwrap();
+        let result = producer.await.unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("central directory declared"));
+        assert_eq!(read, 0);
+        assert!(body.is_empty());
+    }
+
+    #[test]
+    fn local_destination_collisions_respect_case_insensitive_filesystems() {
+        validate_local_destination_path_collisions([("Readme", false), ("README", false)], false)
+            .unwrap();
+
+        let err = validate_local_destination_path_collisions(
+            [("Readme", false), ("README", false)],
+            true,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::InvalidZipEntry { reason, .. }
+                if reason.contains("same local destination path")
+        ));
+    }
+
+    #[test]
+    fn local_destination_parent_collisions_respect_case_insensitive_filesystems() {
+        validate_local_destination_path_collisions(
+            [("Readme", false), ("README/child.txt", false)],
+            false,
+        )
+        .unwrap();
+
+        let err = validate_local_destination_path_collisions(
+            [("Readme", false), ("README/child.txt", false)],
+            true,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::InvalidZipEntry { reason, .. }
+                if reason.contains("same local destination path as file ZIP entry")
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_zero_length_crc_mismatch_fails_before_put_object() {
+        let entry = LocalZipEntry {
+            index: 0,
+            zip_path: "empty.txt".to_string(),
+            destination: "prefix/empty.txt".to_string(),
+            size: 0,
+            compressed_size: 0,
+            compression: Compression::Stored,
+            crc32: 1,
+            catalog_md5: None,
+            is_directory: false,
+        };
+        let options = LocalZipSyncOptions::new(
+            "source.zip",
+            S3Prefix::parse("s3://destination-bucket/prefix/").unwrap(),
+        );
+
+        let report = tokio::time::timeout(
+            Duration::from_secs(1),
+            put_local_file_entry_to_s3(
+                &dummy_s3_client(),
+                std::io::Cursor::new(Vec::<u8>::new()),
+                entry,
+                PutCondition::IfNoneMatch,
+                None,
+                &options,
+            ),
+        )
+        .await
+        .expect("CRC failure should happen before any S3 PutObject attempt");
+
+        assert_eq!(report.status, OperationStatus::Error);
+        assert!(
+            report
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("CRC"))
+        );
+    }
+
+    #[test]
+    fn local_zip_sync_options_reject_delete_extra_at_bucket_root() {
+        let mut options = LocalZipSyncOptions::new(
+            "source.zip",
+            S3Prefix::parse("s3://destination-bucket").unwrap(),
+        );
+        options.delete_extra = true;
+
+        let err = validate_local_zip_sync_options(&options).unwrap_err();
+
+        assert!(err.to_string().contains("delete_extra"));
+    }
+
+    #[tokio::test]
+    async fn local_zip_entries_reject_directory_crc_mismatch() {
+        let zip_bytes = test_zip_bytes(&[("nested/", Compression::Stored, b"".as_slice())]).await;
+        let zip_bytes = set_central_crc32(zip_bytes, "nested/", 1);
+        let source_len = zip_bytes.len() as u64;
+        let reader = async_zip::base::read::mem::ZipFileReader::new(zip_bytes)
+            .await
+            .unwrap();
+        let destination = S3Prefix::parse("s3://destination-bucket/prefix/").unwrap();
+
+        let err =
+            match local_zip_entries_for_s3(reader.file().entries(), &destination, source_len, true)
+            {
+                Ok(_) => panic!("directory entry with nonzero CRC should be rejected"),
+                Err(err) => err,
+            };
+
+        assert!(matches!(
+            err,
+            Error::InvalidZipEntry { ref path, ref reason }
+                if path == "nested/" && reason.contains("zero CRC32")
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_embedded_catalog_falls_back_on_crc_mismatch() {
+        let catalog_json =
+            br#"{"version":1,"entries":[{"path":"a.txt","md5":"2c1743a391305fbf367df8e4f069f9f9"}]}"#;
+        let zip_bytes = test_zip_bytes(&[
+            ("a.txt", Compression::Stored, b"alpha".as_slice()),
+            (
+                EMBEDDED_CATALOG_PATH,
+                Compression::Stored,
+                catalog_json.as_slice(),
+            ),
+        ])
+        .await;
+        let zip_bytes = set_central_crc32(zip_bytes, EMBEDDED_CATALOG_PATH, 0);
+        let path = unique_test_file("local-catalog-crc");
+        tokio::fs::write(&path, zip_bytes).await.unwrap();
+        let reader = open_local_zip_reader(&path).await.unwrap();
+        let catalog_index = reader
+            .file()
+            .entries()
+            .iter()
+            .position(|entry| entry.filename().as_str().unwrap() == EMBEDDED_CATALOG_PATH);
+
+        let catalog = load_local_embedded_catalog(&reader, catalog_index).await;
+
+        assert!(catalog.is_empty());
+        tokio::fs::remove_file(path).await.unwrap();
     }
 
     #[test]
@@ -2116,6 +4062,48 @@ mod tests {
         store
     }
 
+    async fn test_zip_bytes(entries: &[(&str, Compression, &[u8])]) -> Vec<u8> {
+        let mut writer = async_zip::base::write::ZipFileWriter::new(Vec::new());
+        for (path, compression, data) in entries {
+            let entry = async_zip::ZipEntryBuilder::new((*path).to_string().into(), *compression);
+            writer.write_entry_whole(entry, data).await.unwrap();
+        }
+        writer.close().await.unwrap()
+    }
+
+    fn set_central_crc32(mut data: Vec<u8>, path: &str, crc32: u32) -> Vec<u8> {
+        let signature = 0x0201_4b50_u32.to_le_bytes();
+        let mut offset = 0;
+        while let Some(relative) = data[offset..]
+            .windows(signature.len())
+            .position(|window| window == signature)
+        {
+            let index = offset + relative;
+            let file_name_len = u16::from_le_bytes([data[index + 28], data[index + 29]]) as usize;
+            let extra_len = u16::from_le_bytes([data[index + 30], data[index + 31]]) as usize;
+            let comment_len = u16::from_le_bytes([data[index + 32], data[index + 33]]) as usize;
+            let name_start = index + 46;
+            let name_end = name_start + file_name_len;
+            if &data[name_start..name_end] == path.as_bytes() {
+                data[index + 16..index + 20].copy_from_slice(&crc32.to_le_bytes());
+                return data;
+            }
+            offset = name_end + extra_len + comment_len;
+        }
+        panic!("central directory entry for {path} not found");
+    }
+
+    fn unique_test_file(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "s3-unspool-{name}-{}-{nanos}.zip",
+            std::process::id()
+        ))
+    }
+
     fn dummy_s3_client() -> Client {
         let config = aws_sdk_s3::Config::builder()
             .behavior_version_latest()
@@ -2129,5 +4117,19 @@ mod tests {
             ))
             .build();
         Client::from_conf(config)
+    }
+
+    fn local_directory_entry(destination: &str) -> LocalZipEntry {
+        LocalZipEntry {
+            index: 0,
+            zip_path: "empty/".to_string(),
+            destination: destination.to_string(),
+            size: 0,
+            compressed_size: 0,
+            compression: Compression::Stored,
+            crc32: 0,
+            catalog_md5: None,
+            is_directory: true,
+        }
     }
 }

--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -46,7 +46,9 @@ use crate::report::{
 };
 use crate::s3_uri::{S3Prefix, normalize_etag};
 use crate::source::head_source;
-use crate::upload::{invalid_local_path, replace_temp_file, temp_sibling_path};
+use crate::upload::{
+    invalid_local_path, is_platform_path_alias_symlink, replace_temp_file, temp_sibling_path,
+};
 use crate::zip_manifest::{
     ManifestEntry, load_zip_manifest, normalize_zip_entry_path, validate_crc32_value,
 };
@@ -1735,7 +1737,10 @@ async fn create_destination_directory_no_symlink(destination: &Path) -> Result<(
                 "destination directory cannot be a symbolic link".to_string(),
             ));
         }
-        Ok(metadata) if metadata.is_dir() => return Ok(()),
+        Ok(metadata) if metadata.is_dir() => {
+            validate_existing_directory_chain_no_symlink(destination).await?;
+            return Ok(());
+        }
         Ok(_) => {
             return Err(invalid_local_path(
                 destination,
@@ -1765,7 +1770,10 @@ async fn create_destination_directory_no_symlink(destination: &Path) -> Result<(
                     "destination path component cannot be a symbolic link".to_string(),
                 ));
             }
-            Ok(metadata) if metadata.is_dir() => break,
+            Ok(metadata) if metadata.is_dir() => {
+                validate_existing_directory_chain_no_symlink(parent).await?;
+                break;
+            }
             Ok(_) => {
                 return Err(invalid_local_path(
                     parent,
@@ -1789,6 +1797,42 @@ async fn create_destination_directory_no_symlink(destination: &Path) -> Result<(
         ensure_directory_component(&path).await?;
     }
 
+    Ok(())
+}
+
+async fn validate_existing_directory_chain_no_symlink(path: &Path) -> Result<()> {
+    let mut current = Some(path);
+    while let Some(path) = current {
+        if path.as_os_str().is_empty() {
+            break;
+        }
+
+        match tokio::fs::symlink_metadata(path).await {
+            Ok(metadata)
+                if metadata.file_type().is_symlink() && is_platform_path_alias_symlink(path) => {}
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(invalid_local_path(
+                    path,
+                    "destination path component cannot be a symbolic link".to_string(),
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                return Err(invalid_local_path(
+                    path,
+                    "destination path component exists and is not a directory".to_string(),
+                ));
+            }
+            Err(err) => {
+                return Err(invalid_local_path(
+                    path,
+                    format!("cannot inspect destination path component: {err}"),
+                ));
+            }
+        }
+
+        current = path.parent();
+    }
     Ok(())
 }
 

--- a/crates/s3-unspool/src/lib.rs
+++ b/crates/s3-unspool/src/lib.rs
@@ -1,12 +1,14 @@
 //! Streaming ZIP upload and extraction for Amazon S3.
 //!
-//! `s3-unspool` uploads local directories as ZIP objects in S3 and extracts S3
-//! ZIP objects into destination prefixes without writing the archive or
-//! extracted files to local storage.
+//! `s3-unspool` zips local directories and existing S3 prefixes into local or
+//! S3 ZIP files, and unzips local or S3 ZIP files into local directories or S3
+//! prefixes.
 //!
-//! Local directory uploads generate the ZIP once and send it with S3 multipart
-//! upload, so the archive does not need to be sized or written locally before
-//! upload.
+//! Local directory and S3-prefix zip operations generate the ZIP once. S3 ZIP
+//! destinations are streamed with multipart upload, and local ZIP destinations
+//! are written through a temporary sibling file before being renamed into place.
+//! Empty local directories and zero-byte S3 marker objects are preserved as ZIP
+//! directory entries.
 //!
 //! Extraction compares ZIP entries with destination objects listed by
 //! `ListObjectsV2`. Missing objects are uploaded with `If-None-Match: *`, and
@@ -34,11 +36,18 @@
 //! such as [`SyncOptions::source_window_capacity`] or
 //! [`SyncOptions::source_window_memory_budget_mb`].
 //!
-//! ZIPs created with [`upload_directory_zip_to_s3`] include an embedded catalog
-//! at [`EMBEDDED_CATALOG_PATH`] by default. The catalog stores each file path and
+//! ZIPs created with [`upload_directory_zip_to_s3`], [`zip_directory_to_file`],
+//! [`zip_s3_prefix_to_s3`], or [`zip_s3_prefix_to_file`] include an embedded catalog at
+//! [`EMBEDDED_CATALOG_PATH`] by default. The catalog stores each file path and
 //! MD5 digest so later extracts can skip unchanged files before decompressing
-//! them. Set [`SyncOptions::ignore_embedded_catalog`] when you need to measure or
-//! force the fallback extract-and-hash path.
+//! them. Set [`SyncOptions::ignore_embedded_catalog`] when you need to measure
+//! or force the fallback extract-and-hash path.
+//!
+//! ZIP directory entries round-trip as zero-byte S3 marker objects whose keys
+//! end in `/`. Local upload preserves empty directories as ZIP directory
+//! entries, and S3-prefix upload preserves zero-byte S3 marker objects as ZIP
+//! directory entries while rejecting nonzero trailing-slash S3 objects as
+//! ambiguous.
 //!
 //! # Extract an S3 ZIP to a Destination Prefix
 //!
@@ -84,6 +93,27 @@
 //! # }
 //! ```
 //!
+//! # Upload an S3 Prefix as a Cataloged ZIP
+//!
+//! ```no_run
+//! use aws_config::BehaviorVersion;
+//! use aws_sdk_s3::Client;
+//! use s3_unspool::{S3Object, S3Prefix, S3PrefixUploadOptions, zip_s3_prefix_to_s3};
+//!
+//! # async fn run() -> s3_unspool::Result<()> {
+//! let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+//! let client = Client::new(&config);
+//!
+//! let upload = S3PrefixUploadOptions::new(
+//!     S3Prefix::parse("s3://my-bucket/www/")?,
+//!     S3Object::parse("s3://my-bucket/releases/site.zip")?,
+//! );
+//! let report = zip_s3_prefix_to_s3(&client, upload).await?;
+//! println!("uploaded files: {}", report.files);
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # Assumptions
 //!
 //! The crate assumes destination objects use single-part S3 ETags that match the
@@ -108,18 +138,26 @@ mod zip_manifest;
 
 pub use constants::EMBEDDED_CATALOG_PATH;
 pub use error::{Error, Result};
-pub use extract::{sync_zip_to_s3, sync_zip_to_s3_with_clients};
+pub use extract::{
+    sync_zip_to_s3, sync_zip_to_s3_with_clients, unzip_file_to_local, unzip_file_to_s3,
+    unzip_s3_zip_to_local,
+};
 pub use inspect::{S3ZipInfo, inspect_s3_zip};
 pub use options::{
-    PutRetryPolicy, RetryJitter, SyncOptions, UploadOptions, UploadProgress, UploadProgressHandler,
-    adaptive_source_get_concurrency, adaptive_source_window_capacity,
+    LocalUnzipOptions, LocalZipOptions, LocalZipSyncOptions, PutRetryPolicy, RetryJitter,
+    S3PrefixLocalZipOptions, S3PrefixUploadOptions, S3ZipLocalUnzipOptions, SyncOptions,
+    UploadOptions, UploadProgress, UploadProgressHandler, adaptive_source_get_concurrency,
+    adaptive_source_window_capacity,
 };
 pub use report::{
-    ObjectReport, OperationStatus, PutDiagnostics, PutRetryDiagnostics, SourceDiagnostics,
+    LocalUnzipDiagnostics, LocalUnzipReport, LocalZipReport, LocalZipToS3Report, ObjectReport,
+    OperationStatus, PutDiagnostics, PutRetryDiagnostics, S3PrefixUploadReport, SourceDiagnostics,
     SyncDiagnostics, SyncReport, SyncSummary, UploadReport,
 };
 pub use s3_uri::{S3Object, S3Prefix};
-pub use upload::upload_directory_zip_to_s3;
+pub use upload::{
+    upload_directory_zip_to_s3, zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/s3-unspool/src/options.rs
+++ b/crates/s3-unspool/src/options.rs
@@ -203,7 +203,7 @@ pub fn adaptive_source_window_capacity(
 /// Options for zipping a local directory and uploading it as an S3 object.
 #[derive(Clone)]
 pub struct UploadOptions {
-    /// Local directory whose regular files should be included recursively.
+    /// Local directory whose regular files and empty directories should be included recursively.
     pub source_dir: PathBuf,
     /// Destination ZIP object.
     pub destination: S3Object,
@@ -221,6 +221,204 @@ pub struct UploadOptions {
     pub progress: Option<UploadProgressHandler>,
 }
 
+/// Options for zipping a local directory to a local ZIP file.
+#[derive(Clone)]
+pub struct LocalZipOptions {
+    /// Local directory whose regular files and empty directories should be included recursively.
+    pub source_dir: PathBuf,
+    /// Destination ZIP file path.
+    pub destination_zip: PathBuf,
+    /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
+    pub include_catalog: bool,
+    /// Optional progress callback invoked during upload preparation and ZIP streaming.
+    pub progress: Option<UploadProgressHandler>,
+}
+
+/// Options for zipping an S3 prefix and uploading it as an S3 ZIP object.
+#[derive(Clone)]
+pub struct S3PrefixUploadOptions {
+    /// Source prefix whose objects should be included recursively.
+    pub source: S3Prefix,
+    /// Destination ZIP object.
+    pub destination: S3Object,
+    /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
+    pub include_catalog: bool,
+    /// Buffer size used when streaming the ZIP body to S3.
+    ///
+    /// Must be greater than zero and no larger than 16 MiB.
+    pub body_chunk_size: usize,
+    /// Capacity of the in-memory pipe between ZIP production and S3 upload.
+    ///
+    /// Must be greater than zero and no larger than 64 MiB.
+    pub pipe_capacity: usize,
+    /// Optional progress callback invoked during source listing and ZIP streaming.
+    pub progress: Option<UploadProgressHandler>,
+}
+
+/// Options for zipping an S3 prefix to a local ZIP file.
+#[derive(Clone)]
+pub struct S3PrefixLocalZipOptions {
+    /// Source prefix whose objects should be included recursively.
+    pub source: S3Prefix,
+    /// Destination ZIP file path.
+    pub destination_zip: PathBuf,
+    /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
+    pub include_catalog: bool,
+    /// Optional progress callback invoked during source listing and ZIP streaming.
+    pub progress: Option<UploadProgressHandler>,
+}
+
+/// Options for extracting a local ZIP file into an S3 prefix.
+#[derive(Clone)]
+pub struct LocalZipSyncOptions {
+    /// Source ZIP file path.
+    pub source_zip: PathBuf,
+    /// Destination prefix that receives ZIP entries.
+    pub destination: S3Prefix,
+    /// Delete destination objects under the prefix that are not present in the ZIP.
+    ///
+    /// This option requires a non-empty destination prefix so a bucket root is
+    /// never treated as a sync deletion scope.
+    pub delete_extra: bool,
+    /// Ignore the embedded update catalog even when the ZIP contains one.
+    pub ignore_embedded_catalog: bool,
+    /// Collect one operation record per processed object in the returned report.
+    pub collect_operations: bool,
+    /// Maximum number of ZIP entries processed concurrently.
+    pub concurrency: usize,
+    /// Buffer size used when streaming entry bodies to S3.
+    pub body_chunk_size: usize,
+    /// Capacity of the in-memory pipe between decompression and S3 upload.
+    pub pipe_capacity: usize,
+}
+
+/// Options for extracting an S3 ZIP object into a local directory.
+#[derive(Clone)]
+pub struct S3ZipLocalUnzipOptions {
+    /// Source ZIP object.
+    pub source: S3Object,
+    /// Destination local directory.
+    pub destination_dir: PathBuf,
+    /// Collect source scheduler diagnostics in the returned report.
+    pub collect_diagnostics: bool,
+    /// Ignore the embedded update catalog even when the ZIP contains one.
+    pub ignore_embedded_catalog: bool,
+    /// Collect one operation record per processed entry in the returned report.
+    pub collect_operations: bool,
+    /// Maximum number of ZIP entries processed concurrently.
+    pub concurrency: usize,
+    /// Maximum size for planned source ZIP blocks.
+    pub source_block_size: usize,
+    /// Maximum gap that can be read while coalescing adjacent source spans.
+    pub source_block_merge_gap: usize,
+    /// Maximum number of ranged source `GetObject` requests in flight.
+    pub source_get_concurrency: usize,
+    /// Maximum bytes held by the planned source block window.
+    pub source_window_capacity: usize,
+    /// Available memory budget, in MiB, used to derive the source block window.
+    pub source_window_memory_budget_mb: Option<u64>,
+}
+
+/// Options for extracting a local ZIP file into a local directory.
+#[derive(Clone)]
+pub struct LocalUnzipOptions {
+    /// Source ZIP file path.
+    pub source_zip: PathBuf,
+    /// Destination local directory.
+    pub destination_dir: PathBuf,
+    /// Ignore the embedded update catalog even when the ZIP contains one.
+    pub ignore_embedded_catalog: bool,
+    /// Collect one operation record per processed entry in the returned report.
+    pub collect_operations: bool,
+    /// Maximum number of ZIP entries processed concurrently.
+    pub concurrency: usize,
+}
+
+impl S3PrefixUploadOptions {
+    /// Creates upload options for an S3 source prefix and destination object.
+    pub fn new(source: S3Prefix, destination: S3Object) -> Self {
+        Self {
+            source,
+            destination,
+            include_catalog: true,
+            body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
+            pipe_capacity: DEFAULT_PIPE_CAPACITY,
+            progress: None,
+        }
+    }
+}
+
+impl LocalZipOptions {
+    /// Creates options for a local source directory and local destination ZIP.
+    pub fn new(source_dir: impl Into<PathBuf>, destination_zip: impl Into<PathBuf>) -> Self {
+        Self {
+            source_dir: source_dir.into(),
+            destination_zip: destination_zip.into(),
+            include_catalog: true,
+            progress: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for LocalZipOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalZipOptions")
+            .field("source_dir", &self.source_dir)
+            .field("destination_zip", &self.destination_zip)
+            .field("include_catalog", &self.include_catalog)
+            .field(
+                "progress",
+                &self.progress.as_ref().map(|_| "UploadProgressHandler"),
+            )
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for S3PrefixUploadOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("S3PrefixUploadOptions")
+            .field("source", &self.source)
+            .field("destination", &self.destination)
+            .field("include_catalog", &self.include_catalog)
+            .field("body_chunk_size", &self.body_chunk_size)
+            .field("pipe_capacity", &self.pipe_capacity)
+            .field(
+                "progress",
+                &self.progress.as_ref().map(|_| "UploadProgressHandler"),
+            )
+            .finish()
+    }
+}
+
+impl S3PrefixLocalZipOptions {
+    /// Creates options for an S3 source prefix and local destination ZIP.
+    pub fn new(source: S3Prefix, destination_zip: impl Into<PathBuf>) -> Self {
+        Self {
+            source,
+            destination_zip: destination_zip.into(),
+            include_catalog: true,
+            progress: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for S3PrefixLocalZipOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("S3PrefixLocalZipOptions")
+            .field("source", &self.source)
+            .field("destination_zip", &self.destination_zip)
+            .field("include_catalog", &self.include_catalog)
+            .field(
+                "progress",
+                &self.progress.as_ref().map(|_| "UploadProgressHandler"),
+            )
+            .finish()
+    }
+}
+
 impl UploadOptions {
     /// Creates upload options for a local source directory and destination object.
     pub fn new(source_dir: impl Into<PathBuf>, destination: S3Object) -> Self {
@@ -232,6 +430,105 @@ impl UploadOptions {
             pipe_capacity: DEFAULT_PIPE_CAPACITY,
             progress: None,
         }
+    }
+}
+
+impl LocalZipSyncOptions {
+    /// Creates extract options for a local source ZIP file and destination prefix.
+    pub fn new(source_zip: impl Into<PathBuf>, destination: S3Prefix) -> Self {
+        Self {
+            source_zip: source_zip.into(),
+            destination,
+            delete_extra: false,
+            ignore_embedded_catalog: false,
+            collect_operations: true,
+            concurrency: DEFAULT_CONCURRENCY,
+            body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
+            pipe_capacity: DEFAULT_PIPE_CAPACITY,
+        }
+    }
+}
+
+impl std::fmt::Debug for LocalZipSyncOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalZipSyncOptions")
+            .field("source_zip", &self.source_zip)
+            .field("destination", &self.destination)
+            .field("delete_extra", &self.delete_extra)
+            .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
+            .field("collect_operations", &self.collect_operations)
+            .field("concurrency", &self.concurrency)
+            .field("body_chunk_size", &self.body_chunk_size)
+            .field("pipe_capacity", &self.pipe_capacity)
+            .finish()
+    }
+}
+
+impl S3ZipLocalUnzipOptions {
+    /// Creates extract options for a source ZIP object and local destination directory.
+    pub fn new(source: S3Object, destination_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            source,
+            destination_dir: destination_dir.into(),
+            collect_diagnostics: false,
+            ignore_embedded_catalog: false,
+            collect_operations: true,
+            concurrency: DEFAULT_CONCURRENCY,
+            source_block_size: DEFAULT_SOURCE_BLOCK_SIZE,
+            source_block_merge_gap: DEFAULT_SOURCE_BLOCK_MERGE_GAP,
+            source_get_concurrency: DEFAULT_SOURCE_GET_CONCURRENCY,
+            source_window_capacity: DEFAULT_SOURCE_WINDOW_CAPACITY,
+            source_window_memory_budget_mb: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for S3ZipLocalUnzipOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("S3ZipLocalUnzipOptions")
+            .field("source", &self.source)
+            .field("destination_dir", &self.destination_dir)
+            .field("collect_diagnostics", &self.collect_diagnostics)
+            .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
+            .field("collect_operations", &self.collect_operations)
+            .field("concurrency", &self.concurrency)
+            .field("source_block_size", &self.source_block_size)
+            .field("source_block_merge_gap", &self.source_block_merge_gap)
+            .field("source_get_concurrency", &self.source_get_concurrency)
+            .field("source_window_capacity", &self.source_window_capacity)
+            .field(
+                "source_window_memory_budget_mb",
+                &self.source_window_memory_budget_mb,
+            )
+            .finish()
+    }
+}
+
+impl LocalUnzipOptions {
+    /// Creates extract options for a source ZIP file and local destination directory.
+    pub fn new(source_zip: impl Into<PathBuf>, destination_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            source_zip: source_zip.into(),
+            destination_dir: destination_dir.into(),
+            ignore_embedded_catalog: false,
+            collect_operations: true,
+            concurrency: DEFAULT_CONCURRENCY,
+        }
+    }
+}
+
+impl std::fmt::Debug for LocalUnzipOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalUnzipOptions")
+            .field("source_zip", &self.source_zip)
+            .field("destination_dir", &self.destination_dir)
+            .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
+            .field("collect_operations", &self.collect_operations)
+            .field("concurrency", &self.concurrency)
+            .finish()
     }
 }
 
@@ -284,35 +581,35 @@ impl std::fmt::Debug for UploadProgressHandler {
 /// Progress event emitted while preparing and streaming an upload ZIP.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UploadProgress {
-    /// The source directory has been scanned and the total file count is known.
+    /// The source has been scanned and the total entry count is known.
     Planned {
-        /// Total number of files that will be included in the ZIP.
+        /// Total number of files and preserved directory entries included in the ZIP.
         total_files: usize,
         /// Total uncompressed bytes across all files.
         total_bytes: u64,
     },
-    /// A file has started streaming into the ZIP writer.
+    /// A file or preserved directory entry has started streaming into the ZIP writer.
     FileStarted {
-        /// One-based index of the file currently being streamed.
+        /// One-based index of the entry currently being streamed.
         current_file: usize,
-        /// Total number of files that will be included in the ZIP.
+        /// Total number of files and preserved directory entries included in the ZIP.
         total_files: usize,
-        /// Number of files that have finished streaming into the ZIP.
+        /// Number of entries that have finished streaming into the ZIP.
         processed_files: usize,
         /// Uncompressed bytes that have finished streaming into the ZIP.
         processed_bytes: u64,
         /// Total uncompressed bytes across all files.
         total_bytes: u64,
-        /// ZIP path of the file that just started.
+        /// ZIP path of the entry that just started.
         path: String,
     },
     /// A file is still streaming and byte progress has advanced.
     FileProgress {
-        /// One-based index of the file currently being streamed.
+        /// One-based index of the entry currently being streamed.
         current_file: usize,
-        /// Total number of files that will be included in the ZIP.
+        /// Total number of files and preserved directory entries included in the ZIP.
         total_files: usize,
-        /// Number of files that have finished streaming into the ZIP.
+        /// Number of entries that have finished streaming into the ZIP.
         processed_files: usize,
         /// Uncompressed bytes that have streamed into the ZIP producer so far.
         processed_bytes: u64,
@@ -321,17 +618,17 @@ pub enum UploadProgress {
         /// ZIP path of the file currently being streamed.
         path: String,
     },
-    /// One file has finished streaming into the ZIP writer.
+    /// One file or preserved directory entry has finished streaming into the ZIP writer.
     FileFinished {
-        /// Number of files that have finished streaming into the ZIP.
+        /// Number of entries that have finished streaming into the ZIP.
         processed_files: usize,
-        /// Total number of files that will be included in the ZIP.
+        /// Total number of files and preserved directory entries included in the ZIP.
         total_files: usize,
         /// Uncompressed bytes that have finished streaming into the ZIP.
         processed_bytes: u64,
         /// Total uncompressed bytes across all files.
         total_bytes: u64,
-        /// ZIP path of the file that just finished.
+        /// ZIP path of the entry that just finished.
         path: String,
     },
     /// ZIP production has finished writing into the upload pipe.
@@ -339,7 +636,7 @@ pub enum UploadProgress {
     /// S3 multipart upload completion may still be in progress when this event
     /// is emitted.
     Finished {
-        /// Total number of files included in the ZIP.
+        /// Total number of files and preserved directory entries included in the ZIP.
         total_files: usize,
         /// Total uncompressed bytes across all files.
         total_bytes: u64,

--- a/crates/s3-unspool/src/report.rs
+++ b/crates/s3-unspool/src/report.rs
@@ -14,16 +14,57 @@ pub struct UploadReport {
     pub destination: S3Object,
     /// Number of regular files included in the ZIP.
     pub files: usize,
+    /// Number of preserved directory entries included in the ZIP.
+    #[serde(default)]
+    pub directories: usize,
     /// Total uncompressed payload bytes.
     pub uncompressed_bytes: u64,
     /// Total uploaded ZIP object bytes.
     pub zip_bytes: u64,
 }
 
+/// Summary returned by [`crate::zip_s3_prefix_to_s3`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct S3PrefixUploadReport {
+    /// Source prefix that was uploaded.
+    pub source: S3Prefix,
+    /// Destination ZIP object.
+    pub destination: S3Object,
+    /// Number of regular source objects included as ZIP file entries.
+    pub files: usize,
+    /// Number of zero-byte trailing-slash source objects included as ZIP directories.
+    pub directories: usize,
+    /// Total number of ZIP entries written, excluding the embedded catalog.
+    pub entries: usize,
+    /// Total uncompressed payload bytes across regular file entries.
+    pub uncompressed_bytes: u64,
+    /// Total uploaded ZIP object bytes.
+    pub zip_bytes: u64,
+}
+
+/// Summary returned by local ZIP creation helpers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LocalZipReport {
+    /// Source tree that was zipped.
+    pub source: String,
+    /// Destination ZIP file path.
+    pub destination_zip: String,
+    /// Number of regular file entries included in the ZIP.
+    pub files: usize,
+    /// Number of preserved directory entries included in the ZIP.
+    pub directories: usize,
+    /// Total number of ZIP entries written, excluding the embedded catalog.
+    pub entries: usize,
+    /// Total uncompressed payload bytes across regular file entries.
+    pub uncompressed_bytes: u64,
+    /// Size of the generated ZIP file.
+    pub zip_bytes: u64,
+}
+
 /// Aggregate counters for an extract run.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SyncSummary {
-    /// Number of file entries found in the source ZIP, excluding the embedded catalog.
+    /// Number of source ZIP entries found, excluding the embedded catalog.
     pub zip_files: usize,
     /// Number of destination objects listed before extraction.
     pub destination_objects: usize,
@@ -64,6 +105,49 @@ impl SyncReport {
     }
 }
 
+/// Full report returned when extracting a local ZIP into an S3 prefix.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LocalZipToS3Report {
+    /// Source ZIP file path.
+    pub source_zip: String,
+    /// Destination prefix.
+    pub destination: S3Prefix,
+    /// Aggregate extract counters.
+    pub summary: SyncSummary,
+    /// Per-entry operation records.
+    pub operations: Vec<ObjectReport>,
+}
+
+impl LocalZipToS3Report {
+    /// Returns `true` when one or more entry operations failed.
+    pub fn has_errors(&self) -> bool {
+        self.summary.errors > 0
+    }
+}
+
+/// Full report returned when extracting a ZIP into a local directory.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LocalUnzipReport {
+    /// Source ZIP object URI or local file path.
+    pub source_zip: String,
+    /// Destination local directory.
+    pub destination_dir: String,
+    /// Aggregate extract counters.
+    pub summary: SyncSummary,
+    /// Optional source scheduler diagnostics for S3 ZIP sources.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<LocalUnzipDiagnostics>,
+    /// Per-entry operation records.
+    pub operations: Vec<ObjectReport>,
+}
+
+impl LocalUnzipReport {
+    /// Returns `true` when one or more entry operations failed.
+    pub fn has_errors(&self) -> bool {
+        self.summary.errors > 0
+    }
+}
+
 /// Effective extract settings and aggregate diagnostics.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SyncDiagnostics {
@@ -85,6 +169,23 @@ pub struct SyncDiagnostics {
     pub source: SourceDiagnostics,
     /// Aggregate destination `PutObject` counters.
     pub put: PutDiagnostics,
+}
+
+/// Effective local unzip settings and aggregate source diagnostics.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LocalUnzipDiagnostics {
+    /// Effective entry concurrency.
+    pub concurrency: usize,
+    /// Effective source block size in bytes.
+    pub source_block_size: usize,
+    /// Effective source block merge gap in bytes.
+    pub source_block_merge_gap: usize,
+    /// Effective source ranged `GetObject` concurrency.
+    pub source_get_concurrency: usize,
+    /// Effective source block window capacity in bytes.
+    pub source_window_capacity: usize,
+    /// Aggregate source scheduler counters.
+    pub source: SourceDiagnostics,
 }
 
 /// Source scheduler and ranged `GetObject` counters.
@@ -193,7 +294,7 @@ pub enum OperationStatus {
 pub struct ObjectReport {
     /// Operation status.
     pub status: OperationStatus,
-    /// Destination object key.
+    /// Destination object key or local path.
     pub key: String,
     /// Source ZIP path when the operation corresponds to a ZIP entry.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/s3-unspool/src/tests.rs
+++ b/crates/s3-unspool/src/tests.rs
@@ -24,14 +24,20 @@ use crate::range::{
 };
 use crate::report::summarize;
 use crate::s3_uri::{join_destination_key, normalize_etag};
-use crate::upload::{UploadEntry, collect_upload_entries, upload_zip_path, write_upload_zip};
+use crate::upload::{
+    UploadEntry, UploadEntryKind, UploadEntrySource, collect_upload_entries, s3_prefix_zip_path,
+    upload_zip_path, write_upload_zip,
+};
 use crate::zip_manifest::{
     ManifestBuild, ManifestEntry, apply_embedded_catalog, build_manifest_entries,
-    count_zip_file_entries, normalize_zip_file_path,
+    build_manifest_entries_with_size_limit, count_zip_file_entries, normalize_zip_entry_path,
+    normalize_zip_file_path,
 };
 use crate::{
-    Error, ObjectReport, OperationStatus, PutRetryPolicy, S3Object, S3Prefix, SyncOptions,
-    SyncReport, SyncSummary, UploadProgress, UploadProgressHandler,
+    Error, LocalUnzipOptions, LocalZipOptions, ObjectReport, OperationStatus, PutRetryPolicy,
+    S3Object, S3Prefix, S3PrefixLocalZipOptions, SyncOptions, SyncReport, SyncSummary,
+    UploadProgress, UploadProgressHandler, unzip_file_to_local, zip_directory_to_file,
+    zip_s3_prefix_to_file,
 };
 
 #[test]
@@ -230,6 +236,9 @@ fn normalizes_safe_zip_file_paths() {
         Some("a/b.txt".to_string())
     );
     assert_eq!(normalize_zip_file_path("dir/").unwrap(), None);
+    let directory = normalize_zip_entry_path("dir/").unwrap();
+    assert_eq!(directory.path, "dir/");
+    assert!(directory.is_directory);
 }
 
 #[test]
@@ -252,6 +261,7 @@ async fn collects_and_writes_upload_zip_entries() {
     tokio::fs::create_dir_all(root.join("nested"))
         .await
         .unwrap();
+    tokio::fs::create_dir_all(root.join("empty")).await.unwrap();
     tokio::fs::write(root.join("b.txt"), b"bravo")
         .await
         .unwrap();
@@ -265,7 +275,7 @@ async fn collects_and_writes_upload_zip_entries() {
             .iter()
             .map(|entry| entry.zip_path.as_str())
             .collect::<Vec<_>>(),
-        vec!["b.txt", "nested/a.txt"]
+        vec!["b.txt", "empty/", "nested/a.txt"]
     );
 
     let mut data = Vec::new();
@@ -287,22 +297,30 @@ async fn collects_and_writes_upload_zip_entries() {
         .await
         .unwrap();
     let zip_entries = zip.file().entries().to_vec();
-    assert_eq!(zip_entries.len(), 3);
+    assert_eq!(zip_entries.len(), 4);
     assert_eq!(zip_entries[0].filename().as_str().unwrap(), "b.txt");
-    assert_eq!(zip_entries[1].filename().as_str().unwrap(), "nested/a.txt");
+    assert_eq!(zip_entries[1].filename().as_str().unwrap(), "empty/");
+    assert_eq!(zip_entries[2].filename().as_str().unwrap(), "nested/a.txt");
     assert_eq!(
-        zip_entries[2].filename().as_str().unwrap(),
+        zip_entries[3].filename().as_str().unwrap(),
         EMBEDDED_CATALOG_PATH
     );
 
-    let mut nested = zip.reader_with_entry(1).await.unwrap();
+    let mut directory = zip.reader_with_entry(1).await.unwrap();
+    let mut directory_bytes = Vec::new();
+    FuturesAsyncReadExt::read_to_end(&mut directory, &mut directory_bytes)
+        .await
+        .unwrap();
+    assert!(directory_bytes.is_empty());
+
+    let mut nested = zip.reader_with_entry(2).await.unwrap();
     let mut nested_bytes = Vec::new();
     FuturesAsyncReadExt::read_to_end(&mut nested, &mut nested_bytes)
         .await
         .unwrap();
     assert_eq!(nested_bytes, b"alpha");
 
-    let mut catalog_reader = zip.reader_with_entry(2).await.unwrap();
+    let mut catalog_reader = zip.reader_with_entry(3).await.unwrap();
     let mut catalog_bytes = Vec::new();
     FuturesAsyncReadExt::read_to_end(&mut catalog_reader, &mut catalog_bytes)
         .await
@@ -318,14 +336,14 @@ async fn collects_and_writes_upload_zip_entries() {
 async fn upload_zip_rejects_uncompressed_size_overflow() {
     let entries = vec![
         UploadEntry {
-            path: PathBuf::from("missing-a.txt"),
             zip_path: "a.txt".to_string(),
             size: u64::MAX,
+            source: UploadEntrySource::LocalFile(PathBuf::from("missing-a.txt")),
         },
         UploadEntry {
-            path: PathBuf::from("missing-b.txt"),
             zip_path: "b.txt".to_string(),
             size: 1,
+            source: UploadEntrySource::LocalFile(PathBuf::from("missing-b.txt")),
         },
     ];
     let mut data = Vec::new();
@@ -434,6 +452,314 @@ async fn upload_zip_progress_uses_measured_file_bytes() {
 }
 
 #[tokio::test]
+async fn zips_local_directory_to_local_zip_with_empty_directories() {
+    let root = unique_temp_dir("zip-local-source");
+    let output_dir = unique_temp_dir("zip-local-output");
+    let destination_zip = output_dir.join("site.zip");
+    tokio::fs::create_dir_all(root.join("empty")).await.unwrap();
+    tokio::fs::create_dir_all(root.join("nested"))
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(&output_dir).await.unwrap();
+    tokio::fs::write(root.join("nested").join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+
+    let report = zip_directory_to_file(LocalZipOptions::new(&root, &destination_zip))
+        .await
+        .unwrap();
+
+    assert_eq!(report.files, 1);
+    assert_eq!(report.directories, 1);
+    assert!(report.zip_bytes > 0);
+    let data = tokio::fs::read(&destination_zip).await.unwrap();
+    let zip = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let names = zip
+        .file()
+        .entries()
+        .iter()
+        .map(|entry| entry.filename().as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"empty/".to_string()));
+    assert!(names.contains(&"nested/a.txt".to_string()));
+    assert!(names.contains(&EMBEDDED_CATALOG_PATH.to_string()));
+
+    tokio::fs::remove_dir_all(root).await.unwrap();
+    tokio::fs::remove_dir_all(output_dir).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_zip_rejects_destination_inside_source_tree() {
+    let root = unique_temp_dir("zip-local-destination-inside-source");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    tokio::fs::write(root.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    tokio::fs::write(root.join("site.zip"), b"previous archive")
+        .await
+        .unwrap();
+
+    let err = zip_directory_to_file(LocalZipOptions::new(&root, root.join("site.zip")))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("must not be inside source"));
+    tokio::fs::remove_dir_all(root).await.unwrap();
+}
+
+#[tokio::test]
+async fn unzips_local_zip_to_local_directory_and_overwrites_files() {
+    let source_root = unique_temp_dir("unzip-local-source");
+    let zip_dir = unique_temp_dir("unzip-local-zip");
+    let destination = unique_temp_dir("unzip-local-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(source_root.join("empty"))
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(source_root.join("nested"))
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(destination.join("nested"))
+        .await
+        .unwrap();
+    tokio::fs::write(source_root.join("nested").join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    tokio::fs::write(destination.join("nested").join("a.txt"), b"old")
+        .await
+        .unwrap();
+    zip_directory_to_file(LocalZipOptions::new(&source_root, &source_zip))
+        .await
+        .unwrap();
+
+    let report = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &destination))
+        .await
+        .unwrap();
+
+    assert_eq!(report.summary.zip_files, 2);
+    assert_eq!(report.summary.uploaded_changed, 1);
+    assert_eq!(report.summary.uploaded_new, 1);
+    assert_eq!(
+        tokio::fs::read(destination.join("nested").join("a.txt"))
+            .await
+            .unwrap(),
+        b"alpha"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("empty"))
+            .await
+            .unwrap()
+            .is_dir()
+    );
+
+    tokio::fs::remove_dir_all(source_root).await.unwrap();
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_creates_shared_missing_parent_concurrently() {
+    let zip_dir = unique_temp_dir("unzip-shared-parent-zip");
+    let destination = unique_temp_dir("unzip-shared-parent-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let entries = (0..128)
+        .map(|index| {
+            (
+                format!("nested/file-{index}.txt"),
+                Compression::Stored,
+                b"body".as_slice(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let borrowed_entries = entries
+        .iter()
+        .map(|(path, compression, data)| (path.as_str(), *compression, *data))
+        .collect::<Vec<_>>();
+    let zip_bytes = test_zip(&borrowed_entries).await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+    let mut options = LocalUnzipOptions::new(&source_zip, &destination);
+    options.concurrency = 64;
+
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.errors, 0);
+    assert_eq!(report.summary.uploaded_new, 128);
+    for index in 0..128 {
+        assert_eq!(
+            tokio::fs::read(destination.join("nested").join(format!("file-{index}.txt")))
+                .await
+                .unwrap(),
+            b"body"
+        );
+    }
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_rejects_windows_reserved_path_components() {
+    let zip_dir = unique_temp_dir("unzip-windows-path-zip");
+    let destination = unique_temp_dir("unzip-windows-path-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[(
+        "nested/name:stream.txt",
+        Compression::Stored,
+        b"body".as_slice(),
+    )])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &destination))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("unsafe local path component"));
+    assert!(
+        tokio::fs::metadata(destination.join("nested"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_rejects_source_archive_overwrite() {
+    let root = unique_temp_dir("unzip-source-overwrite");
+    let source_zip = root.join("site.zip");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let zip_bytes = test_zip(&[("site.zip", Compression::Stored, b"oops".as_slice())]).await;
+    let zip_len = zip_bytes.len() as u64;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &root))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("source archive"));
+    assert_eq!(
+        tokio::fs::metadata(&source_zip).await.unwrap().len(),
+        zip_len
+    );
+    tokio::fs::remove_dir_all(root).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_rejects_file_directory_destination_collision() {
+    let zip_dir = unique_temp_dir("unzip-local-collision-zip");
+    let destination = unique_temp_dir("unzip-local-collision-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("same", Compression::Stored, b"file".as_slice()),
+        ("same/", Compression::Stored, b"".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &destination))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("same local destination path"));
+    assert!(tokio::fs::metadata(destination.join("same")).await.is_err());
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_rejects_file_parent_destination_collision() {
+    let zip_dir = unique_temp_dir("unzip-local-parent-collision-zip");
+    let destination = unique_temp_dir("unzip-local-parent-collision-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("same", Compression::Stored, b"file".as_slice()),
+        ("same/child.txt", Compression::Stored, b"child".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &destination))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("same local destination path"));
+    assert!(tokio::fs::metadata(destination.join("same")).await.is_err());
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_unzip_rejects_destination_symlink() {
+    let source_root = unique_temp_dir("unzip-symlink-source");
+    let zip_dir = unique_temp_dir("unzip-symlink-zip");
+    let target = unique_temp_dir("unzip-symlink-target");
+    let link = unique_temp_dir("unzip-symlink-link");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&source_root).await.unwrap();
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&target).await.unwrap();
+    tokio::fs::write(source_root.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    zip_directory_to_file(LocalZipOptions::new(&source_root, &source_zip))
+        .await
+        .unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &link))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    tokio::fs::remove_dir_all(source_root).await.unwrap();
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_unzip_rejects_destination_parent_symlink() {
+    let source_root = unique_temp_dir("unzip-parent-symlink-source");
+    let zip_dir = unique_temp_dir("unzip-parent-symlink-zip");
+    let target = unique_temp_dir("unzip-parent-symlink-target");
+    let link = unique_temp_dir("unzip-parent-symlink-link");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&source_root).await.unwrap();
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&target).await.unwrap();
+    tokio::fs::write(source_root.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    zip_directory_to_file(LocalZipOptions::new(&source_root, &source_zip))
+        .await
+        .unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, link.join("out")))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    tokio::fs::remove_dir_all(source_root).await.unwrap();
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
+#[tokio::test]
 async fn upload_rejects_reserved_catalog_path() {
     let root = unique_temp_dir("zip-upload-reserved");
     tokio::fs::create_dir_all(root.join(".s3-unspool"))
@@ -449,6 +775,60 @@ async fn upload_rejects_reserved_catalog_path() {
     tokio::fs::remove_dir_all(root).await.unwrap();
 }
 
+#[test]
+fn s3_prefix_zip_path_preserves_directory_marker_contract() {
+    let source = S3Prefix::parse("s3://bucket/foo/").unwrap();
+
+    assert_eq!(
+        s3_prefix_zip_path(&source, "foo/bar/", 0).unwrap(),
+        Some(("bar/".to_string(), UploadEntryKind::Directory))
+    );
+    assert_eq!(
+        s3_prefix_zip_path(&source, "foo/empty.txt", 0).unwrap(),
+        Some(("empty.txt".to_string(), UploadEntryKind::File))
+    );
+    assert_eq!(s3_prefix_zip_path(&source, "foo/", 0).unwrap(), None);
+
+    let err = s3_prefix_zip_path(&source, "foo/bar/", 1).unwrap_err();
+    assert!(err.to_string().contains("zero-byte directory markers"));
+
+    let err = s3_prefix_zip_path(&source, "foo/../escape.txt", 0).unwrap_err();
+    assert!(err.to_string().contains("relative path component"));
+}
+
+#[tokio::test]
+async fn s3_prefix_upload_zip_writes_directory_markers() {
+    let entries = vec![UploadEntry {
+        zip_path: "empty/".to_string(),
+        size: 0,
+        source: UploadEntrySource::Directory,
+    }];
+
+    let mut data = Vec::new();
+    let catalog_entries = write_upload_zip(&mut data, &entries, true, None)
+        .await
+        .unwrap();
+
+    assert!(catalog_entries.is_empty());
+    let zip = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let zip_entries = zip.file().entries().to_vec();
+    assert_eq!(zip_entries.len(), 2);
+    assert_eq!(zip_entries[0].filename().as_str().unwrap(), "empty/");
+    assert_eq!(
+        zip_entries[1].filename().as_str().unwrap(),
+        EMBEDDED_CATALOG_PATH
+    );
+
+    let mut directory = zip.reader_with_entry(0).await.unwrap();
+    let mut directory_bytes = Vec::new();
+    FuturesAsyncReadExt::read_to_end(&mut directory, &mut directory_bytes)
+        .await
+        .unwrap();
+    assert!(directory_bytes.is_empty());
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn upload_rejects_symlinked_root_directory() {
@@ -462,6 +842,58 @@ async fn upload_rejects_symlinked_root_directory() {
     assert!(err.to_string().contains("symbolic links"));
     tokio::fs::remove_file(link).await.unwrap();
     tokio::fs::remove_dir_all(target).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_zip_rejects_symlinked_destination_parent() {
+    let source = unique_temp_dir("zip-local-parent-symlink-source");
+    let target = unique_temp_dir("zip-local-parent-symlink-target");
+    let link = unique_temp_dir("zip-local-parent-symlink-link");
+    tokio::fs::create_dir_all(&source).await.unwrap();
+    tokio::fs::create_dir_all(&target).await.unwrap();
+    tokio::fs::write(source.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let err = zip_directory_to_file(LocalZipOptions::new(&source, link.join("site.zip")))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    assert!(tokio::fs::metadata(target.join("site.zip")).await.is_err());
+    tokio::fs::remove_dir_all(source).await.unwrap();
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn s3_prefix_local_zip_rejects_symlinked_destination_parent_before_s3() {
+    let target = unique_temp_dir("zip-s3-parent-symlink-target");
+    let link = unique_temp_dir("zip-s3-parent-symlink-link");
+    tokio::fs::create_dir_all(&target).await.unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(1),
+        zip_s3_prefix_to_file(
+            &dummy_s3_client(),
+            S3PrefixLocalZipOptions::new(
+                S3Prefix::parse("s3://bucket/source/").unwrap(),
+                link.join("site.zip"),
+            ),
+        ),
+    )
+    .await
+    .expect("local path validation should run before any S3 request")
+    .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    assert!(tokio::fs::metadata(target.join("site.zip")).await.is_err());
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
 }
 
 #[test]
@@ -894,10 +1326,11 @@ async fn builds_manifest_from_stored_and_deflated_entries() {
         catalog_index: manifest.catalog_index,
     };
 
-    assert_eq!(manifest.entries.len(), 2);
+    assert_eq!(manifest.entries.len(), 3);
     assert_eq!(manifest.entries[0].zip_path, "a.txt");
     assert_eq!(manifest.entries[0].key, "prefix/a.txt");
     assert_eq!(manifest.entries[0].size, 5);
+    assert!(!manifest.entries[0].is_directory);
     assert_eq!(
         manifest.entries[0].catalog_md5.as_deref(),
         Some("2c1743a391305fbf367df8e4f069f9f9")
@@ -905,7 +1338,16 @@ async fn builds_manifest_from_stored_and_deflated_entries() {
     assert_eq!(manifest.entries[1].zip_path, "nested/b.txt");
     assert_eq!(manifest.entries[1].key, "prefix/nested/b.txt");
     assert_eq!(manifest.entries[1].size, 5);
+    assert!(!manifest.entries[1].is_directory);
     assert_eq!(manifest.entries[1].catalog_md5, None);
+    assert_eq!(manifest.entries[2].zip_path, "nested/");
+    assert_eq!(manifest.entries[2].key, "prefix/nested/");
+    assert_eq!(manifest.entries[2].size, 0);
+    assert_eq!(
+        manifest.entries[2].source_span_start,
+        manifest.entries[2].source_span_end
+    );
+    assert!(manifest.entries[2].is_directory);
 
     let stored = reader.file().entries();
     assert_eq!(
@@ -926,6 +1368,59 @@ async fn builds_manifest_from_stored_and_deflated_entries() {
     );
     assert!(manifest.entries[0].source_span_start < manifest.entries[0].source_span_end);
     assert!(manifest.entries[1].source_span_start < manifest.entries[1].source_span_end);
+}
+
+#[tokio::test]
+async fn manifest_rejects_directory_entries_with_nonzero_crc() {
+    let data = test_zip(&[("nested/", Compression::Stored, b"".as_slice())]).await;
+    let data = set_central_crc32(data, "nested/", 1);
+    let source_len = data.len() as u64;
+    let reader = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let destination = S3Prefix::parse("s3://bucket/prefix/").unwrap();
+
+    let err =
+        build_manifest_entries(reader.file().entries(), &destination, source_len).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidZipEntry { ref path, ref reason }
+            if path == "nested/" && reason.contains("zero CRC32")
+    ));
+}
+
+#[tokio::test]
+async fn manifest_size_limit_can_be_disabled_for_local_unzip() {
+    let data = test_zip(&[("large.txt", Compression::Stored, b"alpha".as_slice())]).await;
+    let source_len = data.len() as u64;
+    let reader = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let destination = S3Prefix::parse("s3://bucket/prefix/").unwrap();
+
+    let err = build_manifest_entries_with_size_limit(
+        reader.file().entries(),
+        &destination,
+        source_len,
+        Some(4),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::EntryTooLarge { ref path, size } if path == "large.txt" && size == 5)
+    );
+
+    let manifest = build_manifest_entries_with_size_limit(
+        reader.file().entries(),
+        &destination,
+        source_len,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(manifest.entries.len(), 1);
+    assert_eq!(manifest.entries[0].zip_path, "large.txt");
+    assert_eq!(manifest.entries[0].size, 5);
 }
 
 #[tokio::test]
@@ -1501,6 +1996,27 @@ fn set_catalog_central_compressed_size(mut data: Vec<u8>, size: u32) -> Vec<u8> 
     data
 }
 
+fn set_central_crc32(mut data: Vec<u8>, path: &str, crc32: u32) -> Vec<u8> {
+    let mut index = 0;
+    while index + 46 <= data.len() {
+        if data[index..index + 4] == [0x50, 0x4b, 0x01, 0x02] {
+            let name_len = u16::from_le_bytes([data[index + 28], data[index + 29]]) as usize;
+            let extra_len = u16::from_le_bytes([data[index + 30], data[index + 31]]) as usize;
+            let comment_len = u16::from_le_bytes([data[index + 32], data[index + 33]]) as usize;
+            let name_start = index + 46;
+            let name_end = name_start + name_len;
+            if name_end <= data.len() && &data[name_start..name_end] == path.as_bytes() {
+                data[index + 16..index + 20].copy_from_slice(&crc32.to_le_bytes());
+                return data;
+            }
+            index = name_end + extra_len + comment_len;
+        } else {
+            index += 1;
+        }
+    }
+    panic!("central directory entry for {path} not found");
+}
+
 fn set_catalog_central_size(data: &mut [u8], field_offset: usize, size: u32) {
     let mut index = 0;
     while index + 46 <= data.len() {
@@ -1537,6 +2053,7 @@ fn manifest_entry(path: &str, size: u64) -> ManifestEntry {
         compression: Compression::Stored,
         crc32: 0,
         catalog_md5: None,
+        is_directory: false,
     }
 }
 
@@ -1587,6 +2104,7 @@ fn manifest_entry_with_span(
         compression: Compression::Stored,
         crc32: 0,
         catalog_md5: None,
+        is_directory: false,
     }
 }
 

--- a/crates/s3-unspool/src/tests.rs
+++ b/crates/s3-unspool/src/tests.rs
@@ -759,6 +759,41 @@ async fn local_unzip_rejects_destination_parent_symlink() {
     tokio::fs::remove_file(link).await.unwrap();
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn local_unzip_rejects_existing_destination_under_symlinked_parent() {
+    let source_root = unique_temp_dir("unzip-existing-parent-symlink-source");
+    let zip_dir = unique_temp_dir("unzip-existing-parent-symlink-zip");
+    let target = unique_temp_dir("unzip-existing-parent-symlink-target");
+    let link = unique_temp_dir("unzip-existing-parent-symlink-link");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&source_root).await.unwrap();
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(target.join("extract-here"))
+        .await
+        .unwrap();
+    tokio::fs::write(source_root.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    zip_directory_to_file(LocalZipOptions::new(&source_root, &source_zip))
+        .await
+        .unwrap();
+
+    let err = unzip_file_to_local(LocalUnzipOptions::new(
+        &source_zip,
+        link.join("extract-here"),
+    ))
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    tokio::fs::remove_dir_all(source_root).await.unwrap();
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
 #[tokio::test]
 async fn upload_rejects_reserved_catalog_path() {
     let root = unique_temp_dir("zip-upload-reserved");
@@ -870,6 +905,36 @@ async fn local_zip_rejects_symlinked_destination_parent() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn local_zip_rejects_symlinked_destination_ancestor() {
+    let source = unique_temp_dir("zip-local-ancestor-symlink-source");
+    let target = unique_temp_dir("zip-local-ancestor-symlink-target");
+    let link = unique_temp_dir("zip-local-ancestor-symlink-link");
+    tokio::fs::create_dir_all(&source).await.unwrap();
+    tokio::fs::create_dir_all(target.join("nested"))
+        .await
+        .unwrap();
+    tokio::fs::write(source.join("a.txt"), b"alpha")
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let err = zip_directory_to_file(LocalZipOptions::new(&source, link.join("nested/site.zip")))
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    assert!(
+        tokio::fs::metadata(target.join("nested/site.zip"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(source).await.unwrap();
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn s3_prefix_local_zip_rejects_symlinked_destination_parent_before_s3() {
     let target = unique_temp_dir("zip-s3-parent-symlink-target");
     let link = unique_temp_dir("zip-s3-parent-symlink-link");
@@ -892,6 +957,40 @@ async fn s3_prefix_local_zip_rejects_symlinked_destination_parent_before_s3() {
 
     assert!(err.to_string().contains("symbolic link"));
     assert!(tokio::fs::metadata(target.join("site.zip")).await.is_err());
+    tokio::fs::remove_dir_all(target).await.unwrap();
+    tokio::fs::remove_file(link).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn s3_prefix_local_zip_rejects_symlinked_destination_ancestor_before_s3() {
+    let target = unique_temp_dir("zip-s3-ancestor-symlink-target");
+    let link = unique_temp_dir("zip-s3-ancestor-symlink-link");
+    tokio::fs::create_dir_all(target.join("nested"))
+        .await
+        .unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(1),
+        zip_s3_prefix_to_file(
+            &dummy_s3_client(),
+            S3PrefixLocalZipOptions::new(
+                S3Prefix::parse("s3://bucket/source/").unwrap(),
+                link.join("nested/site.zip"),
+            ),
+        ),
+    )
+    .await
+    .expect("local path validation should run before any S3 request")
+    .unwrap_err();
+
+    assert!(err.to_string().contains("symbolic link"));
+    assert!(
+        tokio::fs::metadata(target.join("nested/site.zip"))
+            .await
+            .is_err()
+    );
     tokio::fs::remove_dir_all(target).await.unwrap();
     tokio::fs::remove_file(link).await.unwrap();
 }

--- a/crates/s3-unspool/src/upload.rs
+++ b/crates/s3-unspool/src/upload.rs
@@ -1,4 +1,7 @@
+use std::collections::HashSet;
+use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
@@ -18,8 +21,14 @@ use crate::constants::{
     S3_SINGLE_PUT_LIMIT,
 };
 use crate::error::{Error, Result, aws_error_message};
-use crate::options::{UploadOptions, UploadProgress, UploadProgressHandler};
-use crate::report::UploadReport;
+use crate::extract::normalized_list_prefix;
+use crate::options::{
+    LocalZipOptions, S3PrefixLocalZipOptions, S3PrefixUploadOptions, UploadOptions, UploadProgress,
+    UploadProgressHandler,
+};
+use crate::report::{LocalZipReport, S3PrefixUploadReport, UploadReport};
+use crate::s3_uri::{S3Object, S3Prefix};
+use crate::zip_manifest::normalize_zip_entry_path;
 
 const UPLOAD_PROGRESS_BYTE_GRANULARITY: u64 = 8 * 1024 * 1024;
 const UPLOAD_MULTIPART_PART_SIZE: usize = 16 * 1024 * 1024;
@@ -29,9 +38,36 @@ const UPLOAD_MULTIPART_MAX_ZIP_BYTES: u64 =
 
 #[derive(Clone, Debug)]
 pub(crate) struct UploadEntry {
-    pub(crate) path: PathBuf,
     pub(crate) zip_path: String,
     pub(crate) size: u64,
+    pub(crate) source: UploadEntrySource,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UploadEntryKind {
+    File,
+    Directory,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum UploadEntrySource {
+    LocalFile(PathBuf),
+    S3Object {
+        bucket: String,
+        key: String,
+        etag: Option<String>,
+    },
+    Directory,
+}
+
+impl UploadEntry {
+    fn is_file(&self) -> bool {
+        !self.is_directory()
+    }
+
+    fn is_directory(&self) -> bool {
+        matches!(self.source, UploadEntrySource::Directory)
+    }
 }
 
 #[derive(Serialize)]
@@ -55,24 +91,18 @@ pub async fn upload_directory_zip_to_s3(
     validate_upload_options(&options)?;
 
     let entries = collect_upload_entries(&options.source_dir).await?;
-    let files = entries.len();
-    let uncompressed_bytes =
-        entries
-            .iter()
-            .map(|entry| entry.size)
-            .try_fold(0_u64, |total, size| {
-                total
-                    .checked_add(size)
-                    .ok_or_else(|| Error::InvalidOption("upload size overflow".to_string()))
-            })?;
+    let files = entries.iter().filter(|entry| entry.is_file()).count();
+    let directories = entries.len().saturating_sub(files);
+    let total_entries = entries.len();
+    let uncompressed_bytes = upload_entries_uncompressed_bytes(&entries)?;
     if let Some(progress) = &options.progress {
         progress.emit(UploadProgress::Planned {
-            total_files: files,
+            total_files: total_entries,
             total_bytes: uncompressed_bytes,
         });
     }
 
-    let upload_id = create_upload(client, &options).await?;
+    let upload_id = create_upload(client, &options.destination).await?;
     let (writer, reader) = tokio::io::duplex(options.pipe_capacity);
     let include_catalog = options.include_catalog;
     let progress = options.progress.clone();
@@ -84,7 +114,7 @@ pub async fn upload_directory_zip_to_s3(
             .inspect(|_| {
                 if let Some(progress) = &finish_progress {
                     progress.emit(UploadProgress::Finished {
-                        total_files: files,
+                        total_files: total_entries,
                         total_bytes,
                     });
                 }
@@ -93,7 +123,7 @@ pub async fn upload_directory_zip_to_s3(
 
     let upload_result = upload_parts(
         client,
-        &options,
+        &options.destination,
         &upload_id,
         reader,
         options.body_chunk_size,
@@ -103,48 +133,325 @@ pub async fn upload_directory_zip_to_s3(
         Ok(result) => result,
         Err(err) => {
             abort_producer(producer).await;
-            return Err(abort_upload_after_error(client, &options, &upload_id, err).await);
+            return Err(
+                abort_upload_after_error(client, &options.destination, &upload_id, err).await,
+            );
         }
     };
 
     match producer.await {
         Ok(Ok(_catalog)) => {}
         Ok(Err(err)) => {
-            return Err(abort_upload_after_error(client, &options, &upload_id, err).await);
+            return Err(
+                abort_upload_after_error(client, &options.destination, &upload_id, err).await,
+            );
         }
         Err(err) => {
-            return Err(abort_upload_after_error(client, &options, &upload_id, err.into()).await);
+            return Err(abort_upload_after_error(
+                client,
+                &options.destination,
+                &upload_id,
+                err.into(),
+            )
+            .await);
         }
     }
 
     if let Err(err) = validate_multipart_upload_has_data(&parts, zip_bytes) {
-        return Err(abort_upload_after_error(client, &options, &upload_id, err).await);
+        return Err(abort_upload_after_error(client, &options.destination, &upload_id, err).await);
     }
 
-    if let Err(err) = complete_upload(client, &options, &upload_id, parts).await {
-        return Err(abort_upload_after_error(client, &options, &upload_id, err).await);
+    if let Err(err) = complete_upload(client, &options.destination, &upload_id, parts).await {
+        return Err(abort_upload_after_error(client, &options.destination, &upload_id, err).await);
     }
 
     Ok(UploadReport {
         source_dir: options.source_dir.display().to_string(),
         destination: options.destination,
         files,
+        directories,
         uncompressed_bytes,
         zip_bytes,
     })
 }
 
-async fn create_upload(client: &Client, options: &UploadOptions) -> Result<String> {
+/// Zips a local directory into a local ZIP file.
+///
+/// The destination is written to a temporary sibling file first and renamed into
+/// place only after ZIP generation succeeds.
+pub async fn zip_directory_to_file(options: LocalZipOptions) -> Result<LocalZipReport> {
+    validate_local_zip_options(&options).await?;
+
+    let entries = collect_upload_entries_with_size_limit(&options.source_dir, None).await?;
+    let files = entries.iter().filter(|entry| entry.is_file()).count();
+    let directories = entries.len().saturating_sub(files);
+    let uncompressed_bytes = upload_entries_uncompressed_bytes(&entries)?;
+    if let Some(progress) = &options.progress {
+        progress.emit(UploadProgress::Planned {
+            total_files: entries.len(),
+            total_bytes: uncompressed_bytes,
+        });
+    }
+
+    let zip_bytes = write_upload_zip_to_local_file(
+        &options.destination_zip,
+        &entries,
+        options.include_catalog,
+        options.progress.clone(),
+        None,
+    )
+    .await?;
+
+    if let Some(progress) = &options.progress {
+        progress.emit(UploadProgress::Finished {
+            total_files: entries.len(),
+            total_bytes: uncompressed_bytes,
+        });
+    }
+
+    Ok(LocalZipReport {
+        source: options.source_dir.display().to_string(),
+        destination_zip: options.destination_zip.display().to_string(),
+        files,
+        directories,
+        entries: entries.len(),
+        uncompressed_bytes,
+        zip_bytes,
+    })
+}
+
+/// Zips an S3 prefix and uploads the archive to S3.
+///
+/// The source objects are listed with `ListObjectsV2` and streamed into the ZIP
+/// with `GetObject`; no local archive or source object body is written to local
+/// storage. Zero-byte source keys ending in `/` are preserved as ZIP directory
+/// entries, while regular zero-byte objects are preserved as file entries.
+pub async fn zip_s3_prefix_to_s3(
+    client: &Client,
+    options: S3PrefixUploadOptions,
+) -> Result<S3PrefixUploadReport> {
+    validate_s3_prefix_upload_options(&options)?;
+
+    let entries = collect_s3_prefix_upload_entries(client, &options).await?;
+    let files = entries.iter().filter(|entry| entry.is_file()).count();
+    let directories = entries.len().saturating_sub(files);
+    let uncompressed_bytes = upload_entries_uncompressed_bytes(&entries)?;
+    if let Some(progress) = &options.progress {
+        progress.emit(UploadProgress::Planned {
+            total_files: entries.len(),
+            total_bytes: uncompressed_bytes,
+        });
+    }
+
+    let upload_id = create_upload(client, &options.destination).await?;
+    let (writer, reader) = tokio::io::duplex(options.pipe_capacity);
+    let include_catalog = options.include_catalog;
+    let progress = options.progress.clone();
+    let finish_progress = progress.clone();
+    let total_entries = entries.len();
+    let total_bytes = uncompressed_bytes;
+    let producer_client = client.clone();
+    let producer = tokio::spawn(async move {
+        write_upload_zip_with_s3_client(
+            writer.compat_write(),
+            &entries,
+            include_catalog,
+            progress,
+            &producer_client,
+        )
+        .await
+        .inspect(|_| {
+            if let Some(progress) = &finish_progress {
+                progress.emit(UploadProgress::Finished {
+                    total_files: total_entries,
+                    total_bytes,
+                });
+            }
+        })
+    });
+
+    let upload_result = upload_parts(
+        client,
+        &options.destination,
+        &upload_id,
+        reader,
+        options.body_chunk_size,
+    )
+    .await;
+    let (parts, zip_bytes) = match upload_result {
+        Ok(result) => result,
+        Err(err) => {
+            abort_producer(producer).await;
+            return Err(
+                abort_upload_after_error(client, &options.destination, &upload_id, err).await,
+            );
+        }
+    };
+
+    match producer.await {
+        Ok(Ok(_catalog)) => {}
+        Ok(Err(err)) => {
+            return Err(
+                abort_upload_after_error(client, &options.destination, &upload_id, err).await,
+            );
+        }
+        Err(err) => {
+            return Err(abort_upload_after_error(
+                client,
+                &options.destination,
+                &upload_id,
+                err.into(),
+            )
+            .await);
+        }
+    }
+
+    if let Err(err) = validate_multipart_upload_has_data(&parts, zip_bytes) {
+        return Err(abort_upload_after_error(client, &options.destination, &upload_id, err).await);
+    }
+
+    if let Err(err) = complete_upload(client, &options.destination, &upload_id, parts).await {
+        return Err(abort_upload_after_error(client, &options.destination, &upload_id, err).await);
+    }
+
+    Ok(S3PrefixUploadReport {
+        source: options.source,
+        destination: options.destination,
+        files,
+        directories,
+        entries: total_entries,
+        uncompressed_bytes,
+        zip_bytes,
+    })
+}
+
+/// Zips an S3 prefix into a local ZIP file.
+///
+/// Source objects are listed and streamed from S3 with `GetObject`. Zero-byte
+/// trailing-slash marker objects are preserved as ZIP directory entries.
+pub async fn zip_s3_prefix_to_file(
+    client: &Client,
+    options: S3PrefixLocalZipOptions,
+) -> Result<LocalZipReport> {
+    validate_local_zip_destination_path(&options.destination_zip).await?;
+
+    let entries = collect_s3_prefix_upload_entries_with_size_limit(
+        client,
+        &S3PrefixUploadOptions {
+            source: options.source.clone(),
+            destination: S3Object {
+                bucket: "__local__".to_string(),
+                key: options.destination_zip.display().to_string(),
+            },
+            include_catalog: options.include_catalog,
+            body_chunk_size: MAX_BODY_CHUNK_SIZE.min(64 * 1024),
+            pipe_capacity: 64 * 1024,
+            progress: options.progress.clone(),
+        },
+        None,
+    )
+    .await?;
+    let files = entries.iter().filter(|entry| entry.is_file()).count();
+    let directories = entries.len().saturating_sub(files);
+    let uncompressed_bytes = upload_entries_uncompressed_bytes(&entries)?;
+    if let Some(progress) = &options.progress {
+        progress.emit(UploadProgress::Planned {
+            total_files: entries.len(),
+            total_bytes: uncompressed_bytes,
+        });
+    }
+
+    let zip_bytes = write_upload_zip_to_local_file(
+        &options.destination_zip,
+        &entries,
+        options.include_catalog,
+        options.progress.clone(),
+        Some(client),
+    )
+    .await?;
+
+    if let Some(progress) = &options.progress {
+        progress.emit(UploadProgress::Finished {
+            total_files: entries.len(),
+            total_bytes: uncompressed_bytes,
+        });
+    }
+
+    Ok(LocalZipReport {
+        source: options.source.uri(),
+        destination_zip: options.destination_zip.display().to_string(),
+        files,
+        directories,
+        entries: entries.len(),
+        uncompressed_bytes,
+        zip_bytes,
+    })
+}
+
+fn upload_entries_uncompressed_bytes(entries: &[UploadEntry]) -> Result<u64> {
+    entries
+        .iter()
+        .filter(|entry| entry.is_file())
+        .map(|entry| entry.size)
+        .try_fold(0_u64, |total, size| {
+            total.checked_add(size).ok_or_else(|| {
+                Error::InvalidOption("total upload size exceeds u64::MAX".to_string())
+            })
+        })
+}
+
+async fn write_upload_zip_to_local_file(
+    destination: &Path,
+    entries: &[UploadEntry],
+    include_catalog: bool,
+    progress: Option<UploadProgressHandler>,
+    s3_client: Option<&Client>,
+) -> Result<u64> {
+    let temp_path = temp_sibling_path(destination)?;
+    let file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .await
+        .map_err(|err| invalid_local_path(&temp_path, format!("cannot create ZIP file: {err}")))?;
+
+    let write_result = write_upload_zip_entries(
+        file.compat_write(),
+        entries,
+        include_catalog,
+        progress,
+        s3_client,
+    )
+    .await;
+    if let Err(err) = write_result {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(err);
+    }
+
+    let zip_bytes = tokio::fs::metadata(&temp_path)
+        .await
+        .map_err(|err| {
+            invalid_local_path(&temp_path, format!("cannot read ZIP file metadata: {err}"))
+        })?
+        .len();
+    if let Err(err) = replace_temp_file(&temp_path, destination, "completed ZIP").await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(err);
+    }
+    Ok(zip_bytes)
+}
+
+async fn create_upload(client: &Client, destination: &S3Object) -> Result<String> {
     let output = client
         .create_multipart_upload()
-        .bucket(&options.destination.bucket)
-        .key(&options.destination.key)
+        .bucket(&destination.bucket)
+        .key(&destination.key)
         .send()
         .await
         .map_err(|err| Error::S3 {
             operation: "CreateMultipartUpload",
-            bucket: options.destination.bucket.clone(),
-            key: options.destination.key.clone(),
+            bucket: destination.bucket.clone(),
+            key: destination.key.clone(),
             message: aws_error_message(&err),
         })?;
 
@@ -155,7 +462,7 @@ async fn create_upload(client: &Client, options: &UploadOptions) -> Result<Strin
 
 async fn upload_parts(
     client: &Client,
-    options: &UploadOptions,
+    destination: &S3Object,
     upload_id: &str,
     mut reader: DuplexStream,
     body_chunk_size: usize,
@@ -180,14 +487,15 @@ async fn upload_parts(
         while let Some((current_part_number, bytes)) =
             take_ready_multipart_part(&mut part_buffer, &mut part_number)?
         {
-            let part = upload_part(client, options, upload_id, current_part_number, bytes).await?;
+            let part =
+                upload_part(client, destination, upload_id, current_part_number, bytes).await?;
             parts.push(part);
         }
     }
 
     if let Some((current_part_number, bytes)) = take_final_multipart_part(part_buffer, part_number)?
     {
-        let part = upload_part(client, options, upload_id, current_part_number, bytes).await?;
+        let part = upload_part(client, destination, upload_id, current_part_number, bytes).await?;
         parts.push(part);
     }
 
@@ -206,7 +514,7 @@ fn validate_multipart_upload_has_data(parts: &[CompletedPart], zip_bytes: u64) -
 
 async fn upload_part(
     client: &Client,
-    options: &UploadOptions,
+    destination: &S3Object,
     upload_id: &str,
     part_number: i32,
     bytes: bytes::Bytes,
@@ -215,8 +523,8 @@ async fn upload_part(
         .map_err(|_| Error::Build("multipart part size does not fit i64".to_string()))?;
     let output = client
         .upload_part()
-        .bucket(&options.destination.bucket)
-        .key(&options.destination.key)
+        .bucket(&destination.bucket)
+        .key(&destination.key)
         .upload_id(upload_id)
         .part_number(part_number)
         .content_length(content_length)
@@ -225,8 +533,8 @@ async fn upload_part(
         .await
         .map_err(|err| Error::S3 {
             operation: "UploadPart",
-            bucket: options.destination.bucket.clone(),
-            key: options.destination.key.clone(),
+            bucket: destination.bucket.clone(),
+            key: destination.key.clone(),
             message: aws_error_message(&err),
         })?;
 
@@ -287,7 +595,7 @@ fn next_part_number(part_number: i32) -> Result<i32> {
 
 async fn complete_upload(
     client: &Client,
-    options: &UploadOptions,
+    destination: &S3Object,
     upload_id: &str,
     mut parts: Vec<CompletedPart>,
 ) -> Result<()> {
@@ -297,8 +605,8 @@ async fn complete_upload(
         .build();
     client
         .complete_multipart_upload()
-        .bucket(&options.destination.bucket)
-        .key(&options.destination.key)
+        .bucket(&destination.bucket)
+        .key(&destination.key)
         .upload_id(upload_id)
         .multipart_upload(upload)
         .send()
@@ -306,36 +614,36 @@ async fn complete_upload(
         .map(|_| ())
         .map_err(|err| Error::S3 {
             operation: "CompleteMultipartUpload",
-            bucket: options.destination.bucket.clone(),
-            key: options.destination.key.clone(),
+            bucket: destination.bucket.clone(),
+            key: destination.key.clone(),
             message: aws_error_message(&err),
         })
 }
 
-async fn abort_upload(client: &Client, options: &UploadOptions, upload_id: &str) -> Result<()> {
+async fn abort_upload(client: &Client, destination: &S3Object, upload_id: &str) -> Result<()> {
     client
         .abort_multipart_upload()
-        .bucket(&options.destination.bucket)
-        .key(&options.destination.key)
+        .bucket(&destination.bucket)
+        .key(&destination.key)
         .upload_id(upload_id)
         .send()
         .await
         .map(|_| ())
         .map_err(|err| Error::S3 {
             operation: "AbortMultipartUpload",
-            bucket: options.destination.bucket.clone(),
-            key: options.destination.key.clone(),
+            bucket: destination.bucket.clone(),
+            key: destination.key.clone(),
             message: aws_error_message(&err),
         })
 }
 
 async fn abort_upload_after_error(
     client: &Client,
-    options: &UploadOptions,
+    destination: &S3Object,
     upload_id: &str,
     original: Error,
 ) -> Error {
-    match abort_upload(client, options, upload_id).await {
+    match abort_upload(client, destination, upload_id).await {
         Ok(()) => original,
         Err(abort) => attach_abort_error(original, abort),
     }
@@ -356,22 +664,163 @@ async fn abort_producer(producer: tokio::task::JoinHandle<Result<Vec<EmbeddedCat
 }
 
 fn validate_upload_options(options: &UploadOptions) -> Result<()> {
-    if options.body_chunk_size == 0 {
+    validate_upload_stream_options(options.body_chunk_size, options.pipe_capacity)
+}
+
+fn validate_s3_prefix_upload_options(options: &S3PrefixUploadOptions) -> Result<()> {
+    validate_upload_stream_options(options.body_chunk_size, options.pipe_capacity)?;
+
+    if options.source.bucket == options.destination.bucket {
+        let list_prefix = normalized_list_prefix(&options.source.prefix);
+        if list_prefix.is_empty() || options.destination.key.starts_with(&list_prefix) {
+            return Err(Error::InvalidOption(format!(
+                "destination {} is inside source prefix {}",
+                options.destination.uri(),
+                options.source.uri()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+async fn validate_local_zip_options(options: &LocalZipOptions) -> Result<()> {
+    reject_local_zip_destination_inside_source(&options.source_dir, &options.destination_zip)
+        .await?;
+    validate_local_zip_destination_path(&options.destination_zip).await
+}
+
+async fn reject_local_zip_destination_inside_source(
+    source_dir: &Path,
+    destination_zip: &Path,
+) -> Result<()> {
+    let source = tokio::fs::canonicalize(source_dir).await.map_err(|err| {
+        invalid_local_path(source_dir, format!("cannot canonicalize directory: {err}"))
+    })?;
+    let destination_parent = destination_zip
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let destination_parent = tokio::fs::canonicalize(destination_parent)
+        .await
+        .map_err(|err| {
+            invalid_local_path(
+                destination_parent,
+                format!("cannot canonicalize destination directory: {err}"),
+            )
+        })?;
+
+    if destination_parent == source || destination_parent.starts_with(&source) {
+        return Err(invalid_local_path(
+            destination_zip,
+            format!(
+                "destination ZIP must not be inside source directory {}",
+                source.display()
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn validate_local_zip_destination_path(destination_zip: &Path) -> Result<()> {
+    reject_local_zip_destination_parent_symlink_chain(destination_zip).await?;
+    reject_existing_local_zip_destination_symlink_or_directory(destination_zip).await
+}
+
+async fn reject_local_zip_destination_parent_symlink_chain(destination_zip: &Path) -> Result<()> {
+    let parent = destination_zip
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut current = parent;
+
+    loop {
+        if current.as_os_str().is_empty() {
+            break;
+        }
+
+        match tokio::fs::symlink_metadata(current).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(invalid_local_path(
+                    current,
+                    "destination path component cannot be a symbolic link".to_string(),
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => {
+                if current == parent {
+                    return Ok(());
+                }
+                return Err(invalid_local_path(
+                    parent,
+                    "destination directory does not exist".to_string(),
+                ));
+            }
+            Ok(_) => {
+                return Err(invalid_local_path(
+                    current,
+                    "destination path component exists and is not a directory".to_string(),
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(invalid_local_path(
+                    current,
+                    format!("cannot inspect destination path component: {err}"),
+                ));
+            }
+        }
+
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
+
+    Err(invalid_local_path(
+        parent,
+        "destination directory does not exist".to_string(),
+    ))
+}
+
+async fn reject_existing_local_zip_destination_symlink_or_directory(
+    destination_zip: &Path,
+) -> Result<()> {
+    match tokio::fs::symlink_metadata(destination_zip).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_local_path(
+            destination_zip,
+            "destination ZIP cannot be a symbolic link".to_string(),
+        )),
+        Ok(metadata) if metadata.is_dir() => Err(invalid_local_path(
+            destination_zip,
+            "destination ZIP path is a directory".to_string(),
+        )),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(invalid_local_path(
+            destination_zip,
+            format!("cannot inspect destination ZIP: {err}"),
+        )),
+    }
+}
+
+fn validate_upload_stream_options(body_chunk_size: usize, pipe_capacity: usize) -> Result<()> {
+    if body_chunk_size == 0 {
         return Err(Error::InvalidOption(
             "body_chunk_size must be greater than zero".to_string(),
         ));
     }
-    if options.body_chunk_size > MAX_BODY_CHUNK_SIZE {
+    if body_chunk_size > MAX_BODY_CHUNK_SIZE {
         return Err(Error::InvalidOption(format!(
             "body_chunk_size must be less than or equal to {MAX_BODY_CHUNK_SIZE}"
         )));
     }
-    if options.pipe_capacity == 0 {
+    if pipe_capacity == 0 {
         return Err(Error::InvalidOption(
             "pipe_capacity must be greater than zero".to_string(),
         ));
     }
-    if options.pipe_capacity > MAX_PIPE_CAPACITY {
+    if pipe_capacity > MAX_PIPE_CAPACITY {
         return Err(Error::InvalidOption(format!(
             "pipe_capacity must be less than or equal to {MAX_PIPE_CAPACITY}"
         )));
@@ -380,6 +829,13 @@ fn validate_upload_options(options: &UploadOptions) -> Result<()> {
 }
 
 pub(crate) async fn collect_upload_entries(source_dir: &Path) -> Result<Vec<UploadEntry>> {
+    collect_upload_entries_with_size_limit(source_dir, Some(S3_SINGLE_PUT_LIMIT)).await
+}
+
+async fn collect_upload_entries_with_size_limit(
+    source_dir: &Path,
+    max_file_size: Option<u64>,
+) -> Result<Vec<UploadEntry>> {
     let metadata = tokio::fs::symlink_metadata(source_dir)
         .await
         .map_err(|err| {
@@ -422,10 +878,12 @@ pub(crate) async fn collect_upload_entries(source_dir: &Path) -> Result<Vec<Uplo
         let mut read_dir = tokio::fs::read_dir(&dir)
             .await
             .map_err(|err| invalid_local_path(&dir, format!("cannot read directory: {err}")))?;
+        let mut has_child = false;
 
         while let Some(entry) = read_dir.next_entry().await.map_err(|err| {
             invalid_local_path(&dir, format!("cannot read directory entry: {err}"))
         })? {
+            has_child = true;
             let path = entry.path();
             let file_type = entry.file_type().await.map_err(|err| {
                 invalid_local_path(&path, format!("cannot read file type: {err}"))
@@ -453,7 +911,9 @@ pub(crate) async fn collect_upload_entries(source_dir: &Path) -> Result<Vec<Uplo
             let metadata = entry.metadata().await.map_err(|err| {
                 invalid_local_path(&path, format!("cannot read file metadata: {err}"))
             })?;
-            if metadata.len() > S3_SINGLE_PUT_LIMIT {
+            if let Some(max_file_size) = max_file_size
+                && metadata.len() > max_file_size
+            {
                 return Err(invalid_local_path(
                     &path,
                     format!(
@@ -471,15 +931,202 @@ pub(crate) async fn collect_upload_entries(source_dir: &Path) -> Result<Vec<Uplo
                 ));
             }
             files.push(UploadEntry {
-                path,
                 zip_path,
                 size: metadata.len(),
+                source: UploadEntrySource::LocalFile(path),
+            });
+        }
+
+        if !has_child && dir != source_dir {
+            let zip_path = format!("{}/", upload_zip_path(&source_dir, &dir)?);
+            files.push(UploadEntry {
+                zip_path,
+                size: 0,
+                source: UploadEntrySource::Directory,
             });
         }
     }
 
     files.sort_unstable_by(|left, right| left.zip_path.cmp(&right.zip_path));
     Ok(files)
+}
+
+pub(crate) async fn collect_s3_prefix_upload_entries(
+    client: &Client,
+    options: &S3PrefixUploadOptions,
+) -> Result<Vec<UploadEntry>> {
+    collect_s3_prefix_upload_entries_with_size_limit(client, options, Some(S3_SINGLE_PUT_LIMIT))
+        .await
+}
+
+async fn collect_s3_prefix_upload_entries_with_size_limit(
+    client: &Client,
+    options: &S3PrefixUploadOptions,
+    max_file_size: Option<u64>,
+) -> Result<Vec<UploadEntry>> {
+    let mut entries = Vec::new();
+    let mut seen_zip_paths = HashSet::new();
+    let mut continuation = None::<String>;
+    let list_prefix = normalized_list_prefix(&options.source.prefix);
+
+    loop {
+        let mut request = client
+            .list_objects_v2()
+            .bucket(&options.source.bucket)
+            .prefix(&list_prefix);
+
+        if let Some(token) = continuation.take() {
+            request = request.continuation_token(token);
+        }
+
+        let output = request.send().await.map_err(|err| Error::S3 {
+            operation: "ListObjectsV2",
+            bucket: options.source.bucket.clone(),
+            key: list_prefix.clone(),
+            message: aws_error_message(&err),
+        })?;
+
+        for object in output.contents() {
+            let key = object.key().ok_or_else(|| Error::S3 {
+                operation: "ListObjectsV2",
+                bucket: options.source.bucket.clone(),
+                key: list_prefix.clone(),
+                message: "listed object did not include a key".to_string(),
+            })?;
+            let size = object.size().ok_or_else(|| Error::S3 {
+                operation: "ListObjectsV2",
+                bucket: options.source.bucket.clone(),
+                key: key.to_string(),
+                message: "listed object did not include a size".to_string(),
+            })?;
+            let size = u64::try_from(size).map_err(|_| Error::S3 {
+                operation: "ListObjectsV2",
+                bucket: options.source.bucket.clone(),
+                key: key.to_string(),
+                message: format!("listed object had negative size {size}"),
+            })?;
+
+            if let Some(entry) = s3_prefix_upload_entry(
+                &options.source,
+                key,
+                size,
+                object.e_tag(),
+                &mut seen_zip_paths,
+                max_file_size,
+            )? {
+                entries.push(entry);
+            }
+        }
+
+        if output.is_truncated().unwrap_or(false) {
+            continuation = output.next_continuation_token().map(str::to_string);
+            if continuation.is_none() {
+                return Err(Error::S3 {
+                    operation: "ListObjectsV2",
+                    bucket: options.source.bucket.clone(),
+                    key: list_prefix.clone(),
+                    message: "response was truncated without a continuation token".to_string(),
+                });
+            }
+        } else {
+            break;
+        }
+    }
+
+    entries.sort_unstable_by(|left, right| left.zip_path.cmp(&right.zip_path));
+    Ok(entries)
+}
+
+fn s3_prefix_upload_entry(
+    source: &S3Prefix,
+    key: &str,
+    size: u64,
+    etag: Option<&str>,
+    seen_zip_paths: &mut HashSet<String>,
+    max_file_size: Option<u64>,
+) -> Result<Option<UploadEntry>> {
+    let Some((zip_path, kind)) = s3_prefix_zip_path(source, key, size)? else {
+        return Ok(None);
+    };
+
+    record_upload_zip_path(seen_zip_paths, &zip_path)?;
+    if kind == UploadEntryKind::File && zip_path == EMBEDDED_CATALOG_PATH {
+        return Err(Error::InvalidZipEntry {
+            path: zip_path,
+            reason: format!("{EMBEDDED_CATALOG_PATH} is reserved for the embedded catalog"),
+        });
+    }
+    if kind == UploadEntryKind::File
+        && let Some(max_file_size) = max_file_size
+        && size > max_file_size
+    {
+        return Err(Error::EntryTooLarge {
+            path: zip_path,
+            size,
+        });
+    }
+
+    Ok(Some(UploadEntry {
+        zip_path,
+        size,
+        source: match kind {
+            UploadEntryKind::File => UploadEntrySource::S3Object {
+                bucket: source.bucket.clone(),
+                key: key.to_string(),
+                etag: etag.map(str::to_string),
+            },
+            UploadEntryKind::Directory => UploadEntrySource::Directory,
+        },
+    }))
+}
+
+fn record_upload_zip_path(seen: &mut HashSet<String>, zip_path: &str) -> Result<()> {
+    if seen.insert(zip_path.to_string()) {
+        Ok(())
+    } else {
+        Err(Error::DuplicateZipPath(zip_path.to_string()))
+    }
+}
+
+pub(crate) fn s3_prefix_zip_path(
+    source: &S3Prefix,
+    key: &str,
+    size: u64,
+) -> Result<Option<(String, UploadEntryKind)>> {
+    let list_prefix = normalized_list_prefix(&source.prefix);
+    let relative = if list_prefix.is_empty() {
+        key
+    } else {
+        key.strip_prefix(&list_prefix)
+            .ok_or_else(|| Error::InvalidZipEntry {
+                path: key.to_string(),
+                reason: format!("key is outside source prefix {}", source.uri()),
+            })?
+    };
+
+    if relative.is_empty() {
+        if size == 0 {
+            return Ok(None);
+        }
+        return Err(Error::InvalidZipEntry {
+            path: key.to_string(),
+            reason: "source prefix root object cannot be represented as a ZIP entry".to_string(),
+        });
+    }
+
+    let zip_path = normalize_zip_entry_path(relative)?;
+    if zip_path.is_directory {
+        if size == 0 {
+            Ok(Some((zip_path.path, UploadEntryKind::Directory)))
+        } else {
+            Err(Error::InvalidZipEntry {
+                path: relative.to_string(),
+                reason: "trailing-slash S3 objects must be zero-byte directory markers".to_string(),
+            })
+        }
+    } else {
+        Ok(Some((zip_path.path, UploadEntryKind::File)))
+    }
 }
 
 pub(crate) async fn write_upload_zip<W>(
@@ -491,15 +1138,36 @@ pub(crate) async fn write_upload_zip<W>(
 where
     W: AsyncWrite + Unpin,
 {
+    write_upload_zip_entries(writer, entries, include_catalog, progress, None).await
+}
+
+async fn write_upload_zip_with_s3_client<W>(
+    writer: W,
+    entries: &[UploadEntry],
+    include_catalog: bool,
+    progress: Option<UploadProgressHandler>,
+    client: &Client,
+) -> Result<Vec<EmbeddedCatalogEntry>>
+where
+    W: AsyncWrite + Unpin,
+{
+    write_upload_zip_entries(writer, entries, include_catalog, progress, Some(client)).await
+}
+
+async fn write_upload_zip_entries<W>(
+    writer: W,
+    entries: &[UploadEntry],
+    include_catalog: bool,
+    progress: Option<UploadProgressHandler>,
+    s3_client: Option<&Client>,
+) -> Result<Vec<EmbeddedCatalogEntry>>
+where
+    W: AsyncWrite + Unpin,
+{
     let mut zip_writer = ZipFileWriter::new(writer);
-    let mut buffer = vec![0_u8; 64 * 1024];
     let mut catalog_entries = Vec::with_capacity(entries.len());
     let total_files = entries.len();
-    let total_bytes = entries.iter().try_fold(0_u64, |total, entry| {
-        total
-            .checked_add(entry.size)
-            .ok_or_else(|| Error::Build("total uncompressed upload size exceeds u64::MAX".into()))
-    })?;
+    let total_bytes = upload_entries_uncompressed_bytes(entries)?;
     let mut processed_bytes = 0_u64;
 
     for (index, entry) in entries.iter().enumerate() {
@@ -515,50 +1183,21 @@ where
             });
         }
 
-        let builder = ZipEntryBuilder::new(entry.zip_path.clone().into(), Compression::Deflate);
-        let mut entry_writer = zip_writer.write_entry_stream(builder).await?;
-        let mut file = tokio::fs::File::open(&entry.path)
-            .await
-            .map_err(|err| invalid_local_path(&entry.path, format!("cannot open file: {err}")))?;
-        let mut hasher = include_catalog.then(Md5::new);
-        let mut file_bytes = 0_u64;
-        let mut next_progress_bytes =
-            processed_bytes.saturating_add(UPLOAD_PROGRESS_BYTE_GRANULARITY);
-
-        loop {
-            let read = TokioAsyncReadExt::read(&mut file, &mut buffer)
-                .await
-                .map_err(|err| {
-                    invalid_local_path(&entry.path, format!("cannot read file: {err}"))
-                })?;
-            if read == 0 {
-                break;
-            }
-            if let Some(hasher) = &mut hasher {
-                hasher.update(&buffer[..read]);
-            }
-            FuturesAsyncWriteExt::write_all(&mut entry_writer, &buffer[..read]).await?;
-            file_bytes = file_bytes.saturating_add(read as u64);
-            let current_processed_bytes = processed_bytes.saturating_add(file_bytes);
-            if current_processed_bytes >= next_progress_bytes {
-                if let Some(progress) = &progress {
-                    progress.emit(UploadProgress::FileProgress {
-                        current_file,
-                        total_files,
-                        processed_files: index,
-                        processed_bytes: current_processed_bytes,
-                        total_bytes,
-                        path: entry.zip_path.clone(),
-                    });
-                }
-                while next_progress_bytes <= current_processed_bytes {
-                    next_progress_bytes =
-                        next_progress_bytes.saturating_add(UPLOAD_PROGRESS_BYTE_GRANULARITY);
-                }
-            }
-        }
-
-        entry_writer.close().await?;
+        let (file_bytes, digest) = write_zip_entry(
+            &mut zip_writer,
+            entry,
+            include_catalog,
+            &progress,
+            UploadProgressContext {
+                current_file,
+                total_files,
+                processed_files: index,
+                processed_bytes,
+                total_bytes,
+            },
+            s3_client,
+        )
+        .await?;
         let processed_files = current_file;
         processed_bytes = processed_bytes.saturating_add(file_bytes);
         if let Some(progress) = &progress {
@@ -570,10 +1209,10 @@ where
                 path: entry.zip_path.clone(),
             });
         }
-        if let Some(hasher) = hasher {
+        if let Some(digest) = digest {
             catalog_entries.push(EmbeddedCatalogEntry {
                 path: entry.zip_path.clone(),
-                md5: hex::encode(hasher.finalize()),
+                md5: digest,
             });
         }
     }
@@ -594,6 +1233,173 @@ where
 
     zip_writer.close().await?;
     Ok(catalog_entries)
+}
+
+#[derive(Clone, Copy)]
+struct UploadProgressContext {
+    current_file: usize,
+    total_files: usize,
+    processed_files: usize,
+    processed_bytes: u64,
+    total_bytes: u64,
+}
+
+async fn write_zip_entry<W>(
+    zip_writer: &mut ZipFileWriter<W>,
+    entry: &UploadEntry,
+    hash_entry: bool,
+    progress: &Option<UploadProgressHandler>,
+    progress_context: UploadProgressContext,
+    s3_client: Option<&Client>,
+) -> Result<(u64, Option<String>)>
+where
+    W: AsyncWrite + Unpin,
+{
+    if entry.is_directory() {
+        let builder = ZipEntryBuilder::new(entry.zip_path.clone().into(), Compression::Stored);
+        zip_writer.write_entry_whole(builder, &[]).await?;
+        return Ok((0, None));
+    }
+
+    let builder = ZipEntryBuilder::new(entry.zip_path.clone().into(), Compression::Deflate);
+    let mut entry_writer = zip_writer.write_entry_stream(builder).await?;
+    let mut state = UploadEntryWriteState {
+        hasher: hash_entry.then(Md5::new),
+        file_bytes: 0,
+        next_progress_bytes: progress_context
+            .processed_bytes
+            .saturating_add(UPLOAD_PROGRESS_BYTE_GRANULARITY),
+    };
+
+    match &entry.source {
+        UploadEntrySource::LocalFile(path) => {
+            let mut buffer = vec![0_u8; 64 * 1024];
+            let mut file = tokio::fs::File::open(path)
+                .await
+                .map_err(|err| invalid_local_path(path, format!("cannot open file: {err}")))?;
+
+            loop {
+                let read = TokioAsyncReadExt::read(&mut file, &mut buffer)
+                    .await
+                    .map_err(|err| invalid_local_path(path, format!("cannot read file: {err}")))?;
+                if read == 0 {
+                    break;
+                }
+                write_upload_chunk(
+                    &mut entry_writer,
+                    &buffer[..read],
+                    &mut state,
+                    entry,
+                    progress,
+                    progress_context,
+                )
+                .await?;
+            }
+        }
+        UploadEntrySource::S3Object { bucket, key, etag } => {
+            let client = s3_client.ok_or_else(|| {
+                Error::Build("S3 upload entries require an S3 client".to_string())
+            })?;
+            let mut request = client.get_object().bucket(bucket).key(key);
+            if let Some(etag) = etag {
+                request = request.if_match(etag);
+            }
+            let output = request.send().await.map_err(|err| Error::S3 {
+                operation: "GetObject",
+                bucket: bucket.clone(),
+                key: key.clone(),
+                message: aws_error_message(&err),
+            })?;
+
+            let mut body = output.body;
+            while let Some(bytes) = body.try_next().await.map_err(|err| Error::S3 {
+                operation: "GetObject",
+                bucket: bucket.clone(),
+                key: key.clone(),
+                message: format!("S3 body read failed: {err}"),
+            })? {
+                write_upload_chunk(
+                    &mut entry_writer,
+                    &bytes,
+                    &mut state,
+                    entry,
+                    progress,
+                    progress_context,
+                )
+                .await?;
+            }
+
+            if state.file_bytes != entry.size {
+                return Err(Error::S3 {
+                    operation: "GetObject",
+                    bucket: bucket.clone(),
+                    key: key.clone(),
+                    message: format!(
+                        "object body returned {} bytes but listing declared {} bytes",
+                        state.file_bytes, entry.size
+                    ),
+                });
+            }
+        }
+        UploadEntrySource::Directory => {
+            return Err(Error::Build(format!(
+                "directory entry {} reached file writer",
+                entry.zip_path
+            )));
+        }
+    }
+
+    entry_writer.close().await?;
+
+    Ok((
+        state.file_bytes,
+        state.hasher.map(|hasher| hex::encode(hasher.finalize())),
+    ))
+}
+
+struct UploadEntryWriteState {
+    hasher: Option<Md5>,
+    file_bytes: u64,
+    next_progress_bytes: u64,
+}
+
+async fn write_upload_chunk<W>(
+    entry_writer: &mut W,
+    bytes: &[u8],
+    state: &mut UploadEntryWriteState,
+    entry: &UploadEntry,
+    progress: &Option<UploadProgressHandler>,
+    progress_context: UploadProgressContext,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    if let Some(hasher) = &mut state.hasher {
+        hasher.update(bytes);
+    }
+    FuturesAsyncWriteExt::write_all(entry_writer, bytes).await?;
+    state.file_bytes = state.file_bytes.saturating_add(bytes.len() as u64);
+    let current_processed_bytes = progress_context
+        .processed_bytes
+        .saturating_add(state.file_bytes);
+    if current_processed_bytes >= state.next_progress_bytes {
+        if let Some(progress) = progress {
+            progress.emit(UploadProgress::FileProgress {
+                current_file: progress_context.current_file,
+                total_files: progress_context.total_files,
+                processed_files: progress_context.processed_files,
+                processed_bytes: current_processed_bytes,
+                total_bytes: progress_context.total_bytes,
+                path: entry.zip_path.clone(),
+            });
+        }
+        while state.next_progress_bytes <= current_processed_bytes {
+            state.next_progress_bytes = state
+                .next_progress_bytes
+                .saturating_add(UPLOAD_PROGRESS_BYTE_GRANULARITY);
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn upload_zip_path(source_dir: &Path, path: &Path) -> Result<String> {
@@ -640,6 +1446,108 @@ pub(crate) fn invalid_local_path(path: &Path, reason: String) -> Error {
         path: path.display().to_string(),
         reason,
     }
+}
+
+pub(crate) fn temp_sibling_path(destination: &Path) -> Result<PathBuf> {
+    let file_name = destination.file_name().ok_or_else(|| {
+        invalid_local_path(
+            destination,
+            "destination must include a file name".to_string(),
+        )
+    })?;
+    let mut temp_name = OsString::from(".");
+    temp_name.push(file_name);
+    temp_name.push(format!(
+        ".s3-unspool-{}-{}.tmp",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+
+    Ok(destination
+        .parent()
+        .map(|parent| parent.join(&temp_name))
+        .unwrap_or_else(|| PathBuf::from(temp_name)))
+}
+
+pub(crate) async fn replace_temp_file(
+    temp_path: &Path,
+    destination: &Path,
+    description: &str,
+) -> Result<()> {
+    match tokio::fs::rename(temp_path, destination).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            replace_temp_file_after_rename_error(temp_path, destination, description, err).await
+        }
+    }
+}
+
+#[cfg(not(windows))]
+async fn replace_temp_file_after_rename_error(
+    _temp_path: &Path,
+    destination: &Path,
+    description: &str,
+    err: std::io::Error,
+) -> Result<()> {
+    Err(invalid_local_path(
+        destination,
+        format!("cannot move {description} into place: {err}"),
+    ))
+}
+
+#[cfg(windows)]
+async fn replace_temp_file_after_rename_error(
+    temp_path: &Path,
+    destination: &Path,
+    description: &str,
+    err: std::io::Error,
+) -> Result<()> {
+    if err.kind() != std::io::ErrorKind::AlreadyExists {
+        return Err(invalid_local_path(
+            destination,
+            format!("cannot move {description} into place: {err}"),
+        ));
+    }
+
+    match tokio::fs::symlink_metadata(destination).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(invalid_local_path(
+                destination,
+                format!("{description} destination cannot be a symbolic link"),
+            ));
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            return Err(invalid_local_path(
+                destination,
+                format!("{description} destination is a directory"),
+            ));
+        }
+        Ok(_) => tokio::fs::remove_file(destination).await.map_err(|remove_err| {
+            invalid_local_path(
+                destination,
+                format!("cannot remove existing destination before moving {description}: {remove_err}"),
+            )
+        })?,
+        Err(metadata_err) if metadata_err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(metadata_err) => {
+            return Err(invalid_local_path(
+                destination,
+                format!("cannot inspect existing destination before moving {description}: {metadata_err}"),
+            ));
+        }
+    }
+
+    tokio::fs::rename(temp_path, destination)
+        .await
+        .map_err(|rename_err| {
+            invalid_local_path(
+                destination,
+                format!("cannot move {description} into place after removing existing destination: {rename_err}"),
+            )
+        })
 }
 
 #[cfg(test)]
@@ -728,5 +1636,111 @@ mod tests {
         options.body_chunk_size = MAX_BODY_CHUNK_SIZE;
         options.pipe_capacity = MAX_PIPE_CAPACITY + 1;
         assert!(validate_upload_options(&options).is_err());
+    }
+
+    #[test]
+    fn s3_prefix_upload_rejects_destination_inside_source_prefix() {
+        let options = S3PrefixUploadOptions::new(
+            crate::s3_uri::S3Prefix::parse("s3://bucket/source/").unwrap(),
+            crate::s3_uri::S3Object::parse("s3://bucket/source/archive.zip").unwrap(),
+        );
+
+        assert!(validate_s3_prefix_upload_options(&options).is_err());
+    }
+
+    #[test]
+    fn s3_prefix_upload_rejects_duplicate_normalized_paths() {
+        let source = crate::s3_uri::S3Prefix::parse("s3://bucket/source/").unwrap();
+        let (first, first_kind) = s3_prefix_zip_path(&source, "source/foo/", 0)
+            .unwrap()
+            .unwrap();
+        let (second, second_kind) = s3_prefix_zip_path(&source, "source/foo//", 0)
+            .unwrap()
+            .unwrap();
+        let mut seen = HashSet::new();
+
+        assert_eq!(first, "foo/");
+        assert_eq!(second, first);
+        assert_eq!(first_kind, UploadEntryKind::Directory);
+        assert_eq!(second_kind, UploadEntryKind::Directory);
+        record_upload_zip_path(&mut seen, &first).unwrap();
+
+        let err = record_upload_zip_path(&mut seen, &second).unwrap_err();
+
+        assert!(matches!(err, Error::DuplicateZipPath(path) if path == "foo/"));
+    }
+
+    #[tokio::test]
+    async fn local_zip_entry_collection_allows_files_above_s3_single_put_limit() {
+        let root = unique_upload_test_dir("large-local-zip-entry");
+        let path = root.join("large.bin");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(S3_SINGLE_PUT_LIMIT + 1).unwrap();
+        drop(file);
+
+        let entries = collect_upload_entries_with_size_limit(&root, None)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].zip_path, "large.bin");
+        assert_eq!(entries[0].size, S3_SINGLE_PUT_LIMIT + 1);
+
+        let err = collect_upload_entries(&root).await.unwrap_err();
+        assert!(err.to_string().contains("S3 single PutObject limit"));
+        tokio::fs::remove_dir_all(root).await.unwrap();
+    }
+
+    #[test]
+    fn s3_prefix_local_zip_entry_allows_objects_above_s3_single_put_limit() {
+        let source = crate::s3_uri::S3Prefix::parse("s3://bucket/source/").unwrap();
+        let mut seen = HashSet::new();
+        let entry = s3_prefix_upload_entry(
+            &source,
+            "source/large.bin",
+            S3_SINGLE_PUT_LIMIT + 1,
+            Some("\"etag\""),
+            &mut seen,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(entry.zip_path, "large.bin");
+        assert_eq!(entry.size, S3_SINGLE_PUT_LIMIT + 1);
+        assert!(matches!(
+            entry.source,
+            UploadEntrySource::S3Object { ref bucket, ref key, ref etag }
+                if bucket == "bucket"
+                    && key == "source/large.bin"
+                    && etag.as_deref() == Some("\"etag\"")
+        ));
+
+        let mut seen = HashSet::new();
+        let err = s3_prefix_upload_entry(
+            &source,
+            "source/large.bin",
+            S3_SINGLE_PUT_LIMIT + 1,
+            Some("\"etag\""),
+            &mut seen,
+            Some(S3_SINGLE_PUT_LIMIT),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, Error::EntryTooLarge { ref path, size } if path == "large.bin" && size == S3_SINGLE_PUT_LIMIT + 1)
+        );
+    }
+
+    fn unique_upload_test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "s3-unspool-upload-{name}-{}-{nanos}",
+            std::process::id()
+        ))
     }
 }

--- a/crates/s3-unspool/src/upload.rs
+++ b/crates/s3-unspool/src/upload.rs
@@ -733,54 +733,57 @@ async fn reject_local_zip_destination_parent_symlink_chain(destination_zip: &Pat
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let mut current = parent;
+    let mut current = Some(parent);
 
-    loop {
-        if current.as_os_str().is_empty() {
+    while let Some(path) = current {
+        if path.as_os_str().is_empty() {
             break;
         }
 
-        match tokio::fs::symlink_metadata(current).await {
+        match tokio::fs::symlink_metadata(path).await {
+            Ok(metadata)
+                if metadata.file_type().is_symlink() && is_platform_path_alias_symlink(path) => {}
             Ok(metadata) if metadata.file_type().is_symlink() => {
                 return Err(invalid_local_path(
-                    current,
+                    path,
                     "destination path component cannot be a symbolic link".to_string(),
                 ));
             }
-            Ok(metadata) if metadata.is_dir() => {
-                if current == parent {
-                    return Ok(());
-                }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                return Err(invalid_local_path(
+                    path,
+                    "destination path component exists and is not a directory".to_string(),
+                ));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 return Err(invalid_local_path(
                     parent,
                     "destination directory does not exist".to_string(),
                 ));
             }
-            Ok(_) => {
-                return Err(invalid_local_path(
-                    current,
-                    "destination path component exists and is not a directory".to_string(),
-                ));
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => {
                 return Err(invalid_local_path(
-                    current,
+                    path,
                     format!("cannot inspect destination path component: {err}"),
                 ));
             }
         }
 
-        let Some(parent) = current.parent() else {
-            break;
-        };
-        current = parent;
+        current = path.parent();
     }
 
-    Err(invalid_local_path(
-        parent,
-        "destination directory does not exist".to_string(),
-    ))
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn is_platform_path_alias_symlink(path: &Path) -> bool {
+    matches!(path.to_str(), Some("/var") | Some("/tmp") | Some("/etc"))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn is_platform_path_alias_symlink(_path: &Path) -> bool {
+    false
 }
 
 async fn reject_existing_local_zip_destination_symlink_or_directory(

--- a/crates/s3-unspool/src/zip_manifest.rs
+++ b/crates/s3-unspool/src/zip_manifest.rs
@@ -13,6 +13,12 @@ use crate::error::{Error, Result};
 use crate::range::{S3RangeReader, SourceClient};
 use crate::s3_uri::S3Prefix;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ZipEntryPath {
+    pub(crate) path: String,
+    pub(crate) is_directory: bool,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct ManifestEntry {
     /// Local-file-header offset used to seek directly to this ZIP entry.
@@ -28,6 +34,7 @@ pub(crate) struct ManifestEntry {
     pub(crate) compression: Compression,
     pub(crate) crc32: u32,
     pub(crate) catalog_md5: Option<String>,
+    pub(crate) is_directory: bool,
 }
 
 #[derive(Clone)]
@@ -46,11 +53,17 @@ pub(crate) async fn load_zip_manifest(
     destination: &S3Prefix,
     ignore_embedded_catalog: bool,
     source_block_size: usize,
+    entry_size_limit: Option<u64>,
 ) -> Result<ZipManifest> {
     let reader = S3RangeReader::new(Arc::clone(&source), source_block_size);
     let reader = ZipFileReader::with_tokio(reader).await?;
     let zip_file = reader.file().clone();
-    let build = build_manifest_entries(zip_file.entries(), destination, source.len)?;
+    let build = build_manifest_entries_with_size_limit(
+        zip_file.entries(),
+        destination,
+        source.len,
+        entry_size_limit,
+    )?;
     let catalog = if ignore_embedded_catalog {
         HashMap::new()
     } else {
@@ -66,10 +79,25 @@ pub(crate) async fn load_zip_manifest(
     Ok(ZipManifest { entries })
 }
 
+#[cfg(test)]
 pub(crate) fn build_manifest_entries(
     entries: &[StoredZipEntry],
     destination: &S3Prefix,
     source_len: u64,
+) -> Result<ManifestBuild> {
+    build_manifest_entries_with_size_limit(
+        entries,
+        destination,
+        source_len,
+        Some(S3_SINGLE_PUT_LIMIT),
+    )
+}
+
+pub(crate) fn build_manifest_entries_with_size_limit(
+    entries: &[StoredZipEntry],
+    destination: &S3Prefix,
+    source_len: u64,
+    entry_size_limit: Option<u64>,
 ) -> Result<ManifestBuild> {
     let mut seen = HashSet::new();
     let mut manifest = Vec::new();
@@ -81,16 +109,16 @@ pub(crate) fn build_manifest_entries(
     source_offsets.sort_unstable();
 
     for (index, stored) in entries.iter().enumerate() {
-        let Some(zip_path) = stored_zip_file_path(stored)? else {
-            continue;
-        };
+        let zip_entry_path = stored_zip_entry_path(stored)?;
+        let zip_path = zip_entry_path.path;
+        let is_directory = zip_entry_path.is_directory;
 
-        if zip_path == EMBEDDED_CATALOG_PATH {
+        if !is_directory && zip_path == EMBEDDED_CATALOG_PATH {
             catalog_index = Some(index);
             continue;
         }
 
-        validate_stored_file_entry(stored, &zip_path)?;
+        validate_stored_entry(stored, &zip_path, is_directory, entry_size_limit)?;
         if !seen.insert(zip_path.clone()) {
             return Err(Error::DuplicateZipPath(zip_path));
         }
@@ -121,6 +149,22 @@ pub(crate) fn build_manifest_entries(
                 ),
             });
         }
+        if is_directory {
+            manifest.push(ManifestEntry {
+                source_offset: source_span_start,
+                source_span_start,
+                source_span_end: source_span_start,
+                zip_path,
+                key,
+                size,
+                compressed_size: stored.compressed_size(),
+                compression: stored.compression(),
+                crc32: stored.crc32(),
+                catalog_md5: None,
+                is_directory,
+            });
+            continue;
+        }
         let source_span_end = next_source_offset(&source_offsets, source_span_start)
             .unwrap_or(payload_span_end)
             .min(payload_span_end);
@@ -143,6 +187,7 @@ pub(crate) fn build_manifest_entries(
             compression: stored.compression(),
             crc32: stored.crc32(),
             catalog_md5: None,
+            is_directory,
         });
     }
 
@@ -158,15 +203,17 @@ pub(crate) fn count_zip_file_entries(entries: &[StoredZipEntry]) -> Result<usize
     let mut count = 0_usize;
 
     for stored in entries {
-        let Some(zip_path) = stored_zip_file_path(stored)? else {
+        let zip_entry_path = stored_zip_entry_path(stored)?;
+        if zip_entry_path.is_directory {
             continue;
         };
+        let zip_path = zip_entry_path.path;
 
         if zip_path == EMBEDDED_CATALOG_PATH {
             continue;
         }
 
-        validate_stored_file_entry(stored, &zip_path)?;
+        validate_stored_entry(stored, &zip_path, false, Some(S3_SINGLE_PUT_LIMIT))?;
         if !seen.insert(zip_path.clone()) {
             return Err(Error::DuplicateZipPath(zip_path));
         }
@@ -176,7 +223,7 @@ pub(crate) fn count_zip_file_entries(entries: &[StoredZipEntry]) -> Result<usize
     Ok(count)
 }
 
-fn stored_zip_file_path(stored: &StoredZipEntry) -> Result<Option<String>> {
+fn stored_zip_entry_path(stored: &StoredZipEntry) -> Result<ZipEntryPath> {
     let raw_path = stored
         .filename()
         .as_str()
@@ -185,10 +232,31 @@ fn stored_zip_file_path(stored: &StoredZipEntry) -> Result<Option<String>> {
             reason: err.to_string(),
         })?;
 
-    normalize_zip_file_path(raw_path)
+    normalize_zip_entry_path(raw_path)
 }
 
-fn validate_stored_file_entry(stored: &StoredZipEntry, zip_path: &str) -> Result<()> {
+fn validate_stored_entry(
+    stored: &StoredZipEntry,
+    zip_path: &str,
+    is_directory: bool,
+    entry_size_limit: Option<u64>,
+) -> Result<()> {
+    if is_directory {
+        if stored.uncompressed_size() != 0 || stored.compressed_size() != 0 {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: "directory entries must be zero length".to_string(),
+            });
+        }
+        if stored.crc32() != 0 {
+            return Err(Error::InvalidZipEntry {
+                path: zip_path.to_string(),
+                reason: "directory entries must have a zero CRC32".to_string(),
+            });
+        }
+        return Ok(());
+    }
+
     match stored.compression() {
         Compression::Stored | Compression::Deflate => {}
         other => {
@@ -200,7 +268,9 @@ fn validate_stored_file_entry(stored: &StoredZipEntry, zip_path: &str) -> Result
     }
 
     let size = stored.uncompressed_size();
-    if size > S3_SINGLE_PUT_LIMIT {
+    if let Some(limit) = entry_size_limit
+        && size > limit
+    {
         return Err(Error::EntryTooLarge {
             path: zip_path.to_string(),
             size,
@@ -308,6 +378,15 @@ pub(crate) fn next_source_offset(sorted_offsets: &[u64], offset: u64) -> Option<
 }
 
 pub(crate) fn normalize_zip_file_path(raw_path: &str) -> Result<Option<String>> {
+    let entry_path = normalize_zip_entry_path(raw_path)?;
+    if entry_path.is_directory {
+        Ok(None)
+    } else {
+        Ok(Some(entry_path.path))
+    }
+}
+
+pub(crate) fn normalize_zip_entry_path(raw_path: &str) -> Result<ZipEntryPath> {
     if raw_path.is_empty() {
         return Err(Error::InvalidZipEntry {
             path: raw_path.to_string(),
@@ -364,9 +443,15 @@ pub(crate) fn normalize_zip_file_path(raw_path: &str) -> Result<Option<String>> 
     }
 
     if is_directory {
-        Ok(None)
+        Ok(ZipEntryPath {
+            path: format!("{trimmed}/"),
+            is_directory: true,
+        })
     } else {
-        Ok(Some(trimmed.to_string()))
+        Ok(ZipEntryPath {
+            path: trimmed.to_string(),
+            is_directory: false,
+        })
     }
 }
 

--- a/crates/s3-unspool/tests/live_s3.rs
+++ b/crates/s3-unspool/tests/live_s3.rs
@@ -7,7 +7,12 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{Delete, ObjectIdentifier};
-use s3_unspool::{OperationStatus, S3Object, S3Prefix, SyncOptions, sync_zip_to_s3};
+use s3_unspool::{
+    LocalZipOptions, OperationStatus, S3Object, S3Prefix, S3PrefixLocalZipOptions,
+    S3PrefixUploadOptions, S3ZipLocalUnzipOptions, SyncOptions, UploadOptions, sync_zip_to_s3,
+    unzip_s3_zip_to_local, upload_directory_zip_to_s3, zip_directory_to_file,
+    zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
+};
 
 type BoxError = Box<dyn Error + Send + Sync>;
 
@@ -88,13 +93,13 @@ async fn run_live_sync_case(client: &Client, bucket: &str, root: &str) -> Result
 
     let report = sync_zip_to_s3(client, options).await?;
 
-    ensure_eq(report.summary.zip_files, 3, "zip file count")?;
+    ensure_eq(report.summary.zip_files, 4, "zip entry count")?;
     ensure_eq(
         report.summary.destination_objects,
         3,
         "destination object count",
     )?;
-    ensure_eq(report.summary.uploaded_new, 1, "new uploads")?;
+    ensure_eq(report.summary.uploaded_new, 2, "new uploads")?;
     ensure_eq(report.summary.uploaded_changed, 1, "changed uploads")?;
     ensure_eq(report.summary.skipped_unchanged, 1, "unchanged skips")?;
     ensure_eq(report.summary.deleted_extra, 1, "extra deletes")?;
@@ -120,6 +125,7 @@ async fn run_live_sync_case(client: &Client, bucket: &str, root: &str) -> Result
         "nested/new.txt",
         OperationStatus::UploadedNew,
     )?;
+    ensure_status(&report.operations, "empty/", OperationStatus::UploadedNew)?;
     ensure_status(
         &report.operations,
         "extra.txt",
@@ -151,11 +157,132 @@ async fn run_live_sync_case(client: &Client, bucket: &str, root: &str) -> Result
         b"brand new".to_vec(),
         "new object content",
     )?;
+    ensure_eq(
+        get_bytes(client, bucket, &format!("{destination_prefix}empty/")).await?,
+        Vec::new(),
+        "directory marker content",
+    )?;
 
     let keys = list_keys(client, bucket, &destination_prefix).await?;
     if keys.contains(&format!("{destination_prefix}extra.txt")) {
         return Err("extra destination object still exists after delete-extra".into());
     }
+
+    let roundtrip_key = format!("{root}/roundtrip/archive.zip");
+    let roundtrip_report = zip_s3_prefix_to_s3(
+        client,
+        S3PrefixUploadOptions::new(
+            S3Prefix::parse(format!("s3://{bucket}/{destination_prefix}"))?,
+            S3Object::parse(format!("s3://{bucket}/{roundtrip_key}"))?,
+        ),
+    )
+    .await?;
+    ensure_eq(roundtrip_report.files, 3, "roundtrip file count")?;
+    ensure_eq(roundtrip_report.directories, 1, "roundtrip directory count")?;
+    ensure_eq(roundtrip_report.entries, 4, "roundtrip entry count")?;
+
+    let roundtrip_zip = get_bytes(client, bucket, &roundtrip_key).await?;
+    ensure_zip_contains(&roundtrip_zip, "empty/").await?;
+
+    let local_unzip_dir = env::temp_dir().join(format!(
+        "s3-unspool-live-unzip-{root_run}",
+        root_run = root.replace('/', "-")
+    ));
+    let local_zip_dir = env::temp_dir().join(format!(
+        "s3-unspool-live-zip-{root_run}",
+        root_run = root.replace('/', "-")
+    ));
+    let local_source_dir = env::temp_dir().join(format!(
+        "s3-unspool-live-source-{root_run}",
+        root_run = root.replace('/', "-")
+    ));
+    let local_zip_path = local_zip_dir.join("prefix.zip");
+
+    unzip_s3_zip_to_local(
+        client,
+        S3ZipLocalUnzipOptions::new(
+            S3Object::parse(format!("s3://{bucket}/{roundtrip_key}"))?,
+            &local_unzip_dir,
+        ),
+    )
+    .await?;
+    ensure_eq(
+        tokio::fs::read(local_unzip_dir.join("nested").join("new.txt")).await?,
+        b"brand new".to_vec(),
+        "s3 zip to local file content",
+    )?;
+    ensure_eq(
+        tokio::fs::metadata(local_unzip_dir.join("empty"))
+            .await?
+            .is_dir(),
+        true,
+        "s3 zip to local empty directory",
+    )?;
+
+    tokio::fs::create_dir_all(&local_zip_dir).await?;
+    zip_s3_prefix_to_file(
+        client,
+        S3PrefixLocalZipOptions::new(
+            S3Prefix::parse(format!("s3://{bucket}/{destination_prefix}"))?,
+            &local_zip_path,
+        ),
+    )
+    .await?;
+    let local_prefix_zip = tokio::fs::read(&local_zip_path).await?;
+    ensure_zip_contains(&local_prefix_zip, "empty/").await?;
+
+    tokio::fs::create_dir_all(local_source_dir.join("empty")).await?;
+    tokio::fs::write(local_source_dir.join("local.txt"), b"from local").await?;
+    let local_source_zip_key = format!("{root}/local-source/archive.zip");
+    upload_directory_zip_to_s3(
+        client,
+        UploadOptions::new(
+            &local_source_dir,
+            S3Object::parse(format!("s3://{bucket}/{local_source_zip_key}"))?,
+        ),
+    )
+    .await?;
+    let local_source_extract_prefix = format!("{root}/local-source-dest/");
+    sync_zip_to_s3(
+        client,
+        SyncOptions::new(
+            S3Object::parse(format!("s3://{bucket}/{local_source_zip_key}"))?,
+            S3Prefix::parse(format!("s3://{bucket}/{local_source_extract_prefix}"))?,
+        ),
+    )
+    .await?;
+    ensure_eq(
+        get_bytes(
+            client,
+            bucket,
+            &format!("{local_source_extract_prefix}local.txt"),
+        )
+        .await?,
+        b"from local".to_vec(),
+        "local dir to s3 zip to s3 prefix file content",
+    )?;
+    ensure_eq(
+        get_bytes(
+            client,
+            bucket,
+            &format!("{local_source_extract_prefix}empty/"),
+        )
+        .await?,
+        Vec::new(),
+        "local dir to s3 zip to s3 prefix marker",
+    )?;
+
+    let local_only_zip_path = local_zip_dir.join("local.zip");
+    zip_directory_to_file(LocalZipOptions::new(
+        &local_source_dir,
+        &local_only_zip_path,
+    ))
+    .await?;
+    ensure_zip_contains(&tokio::fs::read(&local_only_zip_path).await?, "empty/").await?;
+
+    let _ = tokio::fs::remove_dir_all(local_unzip_dir).await;
+    let _ = tokio::fs::remove_dir_all(local_zip_dir).await;
+    let _ = tokio::fs::remove_dir_all(local_source_dir).await;
 
     Ok(())
 }
@@ -180,7 +307,27 @@ async fn build_zip() -> Result<Vec<u8>, async_zip::error::ZipError> {
             b"brand new",
         )
         .await?;
+    writer
+        .write_entry_whole(
+            ZipEntryBuilder::new("empty/".to_string().into(), Compression::Stored),
+            b"",
+        )
+        .await?;
     writer.close().await
+}
+
+async fn ensure_zip_contains(data: &[u8], path: &str) -> Result<(), BoxError> {
+    let reader = async_zip::base::read::mem::ZipFileReader::new(data.to_vec()).await?;
+    if reader
+        .file()
+        .entries()
+        .iter()
+        .any(|entry| entry.filename().as_str().ok() == Some(path))
+    {
+        Ok(())
+    } else {
+        Err(format!("roundtrip ZIP is missing {path}").into())
+    }
 }
 
 async fn put_bytes(


### PR DESCRIPTION
## Summary

- replace the CLI surface with `zip` and `unzip` commands across local and S3 endpoint combinations
- add local ZIP output and local unzip support with temp-file writes, symlink guards, unsafe path rejection, case-insensitive collision checks, and source archive overwrite protection
- preserve empty directories and S3 trailing-slash directory markers through ZIP/S3 round trips, including report and docs updates
- extend local/S3 extraction and zipping tests, including corruption, filesystem, reporting, and live S3 coverage

## Why

The old `upload`/`extract` CLI was S3-shaped and did not cover local ZIP files or round-tripping empty directories cleanly. This refactor makes source and destination endpoints explicit while keeping the library paths consistent across local and S3 flows.

## Validation

- `cargo +1.95.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.95.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.95.0 check`
- `cargo +1.95.0 test`
