### PR TITLE
release: add cargo-dist CLI artifacts

### DIFF
--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -117,9 +117,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-installer.sh" |
-            sh
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+          cargo install cargo-dist --locked --version "$DIST_VERSION"
 
       - name: Cache dist
         if: ${{ steps.release.outputs.publishing == 'true' }}
@@ -142,7 +141,8 @@ jobs:
             dist plan --output-format=json > plan-dist-manifest.json
           fi
           cat plan-dist-manifest.json
-          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          manifest="$(jq -c '.' plan-dist-manifest.json)"
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
 
       - name: Upload dist manifest
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -163,11 +163,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Install Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
 
       - name: Install Rust toolchain
         shell: bash
@@ -379,7 +374,8 @@ jobs:
           set -euo pipefail
           dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
           cat dist-manifest.json
-          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          manifest="$(jq -c '.' dist-manifest.json)"
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
 
       - name: Upload staged dist manifest
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -406,6 +402,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Install Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
 
       - name: Install Rust toolchain
         shell: bash

--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -1,41 +1,166 @@
 name: Publish s3-unspool
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/publish-s3-unspool.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/s3-unspool/**"
+      - "crates/s3-unspool-cli/**"
+      - "dist-workspace.toml"
+      - "rust-toolchain.toml"
   workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: publish-s3-unspool
+  group: publish-s3-unspool-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
-jobs:
-  publish:
-    name: Publish crate
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      id-token: write
-    env:
-      RUSTUP_TOOLCHAIN: "1.95.0"
-      RUSTDOCFLAGS: "-D warnings"
-    steps:
-      - name: Require main branch
-        run: |
-          set -euo pipefail
-          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "This workflow must be dispatched from main; got $GITHUB_REF" >&2
-            exit 1
-          fi
+env:
+  DIST_VERSION: "0.31.0"
+  RUSTUP_TOOLCHAIN: "1.95.0"
+  RUSTDOCFLAGS: "-D warnings"
 
+jobs:
+  plan:
+    name: Plan release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      val: ${{ steps.plan.outputs.manifest }}
+      tag: ${{ steps.release.outputs.tag }}
+      tag-flag: ${{ steps.release.outputs.tag-flag }}
+      publishing: ${{ steps.release.outputs.publishing }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: Read and validate release version
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          publishing=false
+          tag_flag=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            publishing=true
+            if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+              echo "This workflow must be dispatched from main; got $GITHUB_REF" >&2
+              exit 1
+            fi
+          fi
+
+          version="$(python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          root = pathlib.Path(".")
+          workspace = tomllib.loads((root / "Cargo.toml").read_text())
+          library = tomllib.loads((root / "crates/s3-unspool/Cargo.toml").read_text())
+          cli = tomllib.loads((root / "crates/s3-unspool-cli/Cargo.toml").read_text())
+
+          lib_version = library["package"]["version"]
+          cli_version = cli["package"]["version"]
+          dep_version = workspace["workspace"]["dependencies"]["s3-unspool"]["version"]
+          expected_dep = f"={lib_version}"
+
+          if cli_version != lib_version:
+              raise SystemExit(
+                  f"s3-unspool-cli version {cli_version} must match s3-unspool {lib_version}"
+              )
+          if dep_version != expected_dep:
+              raise SystemExit(
+                  f"workspace s3-unspool dependency must be {expected_dep}; got {dep_version}"
+              )
+
+          print(lib_version)
+          PY
+          )"
+          tag="v${version}"
+          if [ "$publishing" = "true" ]; then
+            tag_flag="--tag=${tag}"
+            git fetch --tags --force origin
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "Tag ${tag} already exists" >&2
+              exit 1
+            fi
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "GitHub Release ${tag} already exists" >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "tag-flag=${tag_flag}"
+            echo "publishing=${publishing}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-installer.sh" |
+            sh
+
+      - name: Cache dist
+        if: ${{ steps.release.outputs.publishing == 'true' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/dist
+
+      - name: Run dist plan
+        id: plan
+        shell: bash
+        env:
+          PUBLISHING: ${{ steps.release.outputs.publishing }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$PUBLISHING" = "true" ]; then
+            dist host --steps=create --tag="$TAG" --output-format=json > plan-dist-manifest.json
+          else
+            dist plan --output-format=json > plan-dist-manifest.json
+          fi
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload dist manifest
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
+
+  qa:
+    name: Release QA
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
+        shell: bash
         run: |
           set -euo pipefail
           rustup toolchain install "$RUSTUP_TOOLCHAIN" \
@@ -45,64 +170,395 @@ jobs:
           rustup default "$RUSTUP_TOOLCHAIN"
           rustc --version
 
-      - name: Read crate version
-        id: crate
-        run: |
-          set -euo pipefail
-          version="$(python3 - <<'PY'
-          import pathlib
-          import tomllib
-
-          manifest = pathlib.Path("crates/s3-unspool/Cargo.toml")
-          data = tomllib.loads(manifest.read_text())
-          print(data["package"]["version"])
-          PY
-          )"
-          tag="v${version}"
-          {
-            echo "version=${version}"
-            echo "tag=${tag}"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Reject existing release tag
-        run: |
-          set -euo pipefail
-          git fetch --tags --force origin
-          if git rev-parse -q --verify "refs/tags/${{ steps.crate.outputs.tag }}" >/dev/null; then
-            echo "Tag ${{ steps.crate.outputs.tag }} already exists" >&2
-            exit 1
-          fi
-
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Run crate tests
+      - name: Run library tests
         run: cargo test -p s3-unspool
 
-      - name: Run clippy
+      - name: Run CLI tests
+        run: cargo test -p s3-unspool-cli
+
+      - name: Run library clippy
         run: cargo clippy -p s3-unspool --all-targets -- -D warnings
 
-      - name: Build crate documentation
+      - name: Run CLI clippy
+        run: cargo clippy -p s3-unspool-cli --all-targets -- -D warnings
+
+      - name: Build library documentation
         run: cargo doc -p s3-unspool --no-deps
 
-      - name: Verify crate package
+      - name: Verify library package
         run: cargo publish -p s3-unspool --dry-run
+
+      - name: Verify CLI package manifest
+        run: cargo package -p s3-unspool-cli --list
+
+  build-local-artifacts:
+    name: Build local artifacts (${{ join(matrix.targets, ', ') }})
+    needs:
+      - plan
+      - qa
+    if: ${{ always() && needs.plan.result == 'success' && needs.qa.result == 'success' && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && needs.plan.outputs.publishing == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    steps:
+      - name: Enable Windows long paths
+        run: git config --global core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Install dist
+        run: ${{ matrix.install_dist.run }}
+
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+
+      - name: Build artifacts
+        run: |
+          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "dist ran successfully"
+
+      - name: Post-build
+        id: cargo-dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "paths<<EOF"
+            dist print-upload-files-from-manifest --manifest dist-manifest.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  build-global-artifacts:
+    name: Build global artifacts
+    needs:
+      - plan
+      - build-local-artifacts
+    if: ${{ always() && needs.plan.result == 'success' && needs.build-local-artifacts.result == 'success' && needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install cached dist
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+
+      - name: Make dist executable
+        run: chmod +x ~/.cargo/bin/dist
+
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+
+      - name: Build global artifacts
+        id: cargo-dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json --artifacts=global > dist-manifest.json
+          {
+            echo "paths<<EOF"
+            jq --raw-output ".upload_files[]" dist-manifest.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  host:
+    name: Stage hosted artifacts
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && needs.build-local-artifacts.result == 'success' && needs.build-global-artifacts.result == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      val: ${{ steps.host.outputs.manifest }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install cached dist
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: cargo-dist-cache
+          path: ~/.cargo/bin/
+
+      - name: Make dist executable
+        run: chmod +x ~/.cargo/bin/dist
+
+      - name: Fetch artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+
+      - name: Stage artifacts
+        id: host
+        shell: bash
+        run: |
+          set -euo pipefail
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload staged dist manifest
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: artifacts-dist-manifest
+          path: dist-manifest.json
+
+  publish:
+    name: Publish crates
+    needs:
+      - plan
+      - qa
+      - host
+    if: ${{ always() && needs.plan.result == 'success' && needs.qa.result == 'success' && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PLAN: ${{ needs.plan.outputs.val }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+          rustup default "$RUSTUP_TOOLCHAIN"
+          rustc --version
+
+      - name: Validate crates.io release inputs
+        id: crate
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          plan = json.loads(os.environ["PLAN"])
+          root = pathlib.Path(".")
+          library = tomllib.loads((root / "crates/s3-unspool/Cargo.toml").read_text())
+          cli = tomllib.loads((root / "crates/s3-unspool-cli/Cargo.toml").read_text())
+          workspace = tomllib.loads((root / "Cargo.toml").read_text())
+
+          version = library["package"]["version"]
+          if cli["package"]["version"] != version:
+              raise SystemExit("CLI and library versions must match before publishing")
+          if workspace["workspace"]["dependencies"]["s3-unspool"]["version"] != f"={version}":
+              raise SystemExit("workspace s3-unspool dependency must exactly match the release version")
+          if plan["announcement_tag"] != f"v{version}":
+              raise SystemExit(
+                  f"dist plan tag {plan['announcement_tag']} does not match v{version}"
+              )
+          if plan.get("releases", [{}])[0].get("app_name") != "s3-unspool-cli":
+              raise SystemExit("dist plan must release only s3-unspool-cli")
+          print(version)
+          PY
+          )"
+          {
+            echo "version=${version}"
+            echo "tag=v${version}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reject existing crate versions
+        shell: bash
+        env:
+          VERSION: ${{ steps.crate.outputs.version }}
+        run: |
+          set -euo pipefail
+          check_absent() {
+            crate="$1"
+            status="$(curl -L -sS -o response.json -w "%{http_code}" \
+              -H "User-Agent: alessandrobologna/s3-unspool release workflow" \
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
+            if [ "$status" = "200" ]; then
+              echo "crate ${crate} ${VERSION} is already published" >&2
+              exit 1
+            fi
+            if [ "$status" != "404" ]; then
+              cat response.json >&2
+              echo "unexpected crates.io response ${status} for ${crate} ${VERSION}" >&2
+              exit 1
+            fi
+          }
+          check_absent s3-unspool
+          check_absent s3-unspool-cli
+
+      - name: Dry-run library publish
+        run: cargo publish -p s3-unspool --dry-run
+
+      - name: Verify CLI package manifest
+        run: cargo package -p s3-unspool-cli --list
 
       - name: Authenticate to crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
-      - name: Publish crate
+      - name: Publish library crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p s3-unspool
 
-      - name: Tag published commit
+      - name: Wait for library propagation
+        shell: bash
+        env:
+          VERSION: ${{ steps.crate.outputs.version }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.crate.outputs.tag }}" \
-            -m "Release s3-unspool ${{ steps.crate.outputs.version }}" \
-            "$GITHUB_SHA"
-          git push origin "refs/tags/${{ steps.crate.outputs.tag }}"
+          for attempt in {1..30}; do
+            status="$(curl -L -sS -o response.json -w "%{http_code}" \
+              -H "User-Agent: alessandrobologna/s3-unspool release workflow" \
+              "https://crates.io/api/v1/crates/s3-unspool/${VERSION}")"
+            if [ "$status" = "200" ]; then
+              exit 0
+            fi
+            if [ "$status" != "404" ]; then
+              cat response.json >&2
+              echo "unexpected crates.io response ${status} while waiting for s3-unspool ${VERSION}" >&2
+              exit 1
+            fi
+            echo "s3-unspool ${VERSION} is not visible yet; attempt ${attempt}/30"
+            sleep 20
+          done
+          echo "s3-unspool ${VERSION} did not become visible on crates.io in time" >&2
+          exit 1
+
+      - name: Dry-run CLI publish
+        run: cargo publish -p s3-unspool-cli --dry-run
+
+      - name: Publish CLI crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p s3-unspool-cli
+
+  announce:
+    name: Create GitHub Release
+    needs:
+      - plan
+      - host
+      - publish
+    if: ${{ always() && needs.plan.result == 'success' && needs.host.result == 'success' && needs.publish.result == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Remove internal manifests
+        run: rm -f artifacts/*-dist-manifest.json
+
+      - name: Create GitHub Release
+        env:
+          PRERELEASE_FLAG: "${{ fromJson(needs.host.outputs.val).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(needs.host.outputs.val).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(needs.host.outputs.val).announcement_github_body }}"
+          RELEASE_COMMIT: ${{ github.sha }}
+          TAG: ${{ needs.plan.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s' "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.md"
+          args=(
+            "$TAG"
+            --target "$RELEASE_COMMIT"
+            --title "$ANNOUNCEMENT_TITLE"
+            --notes-file "$RUNNER_TEMP/notes.md"
+          )
+          if [ -n "$PRERELEASE_FLAG" ]; then
+            args+=("$PRERELEASE_FLAG")
+          fi
+          gh release create "${args[@]}" artifacts/*

--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           set -euo pipefail
           rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
-          cargo install cargo-dist --locked --version "$DIST_VERSION"
+          cargo install cargo-dist --locked --version "$DIST_VERSION" --force
 
       - name: Cache dist
         if: ${{ steps.release.outputs.publishing == 'true' }}
@@ -225,18 +225,12 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Install Rust non-interactively if not already installed
-        if: ${{ matrix.container }}
+      - name: Install dist
         shell: bash
         run: |
           set -euo pipefail
-          if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
-
-      - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+          cargo install cargo-dist --locked --version "$DIST_VERSION" --force
 
       - name: Fetch local artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -460,7 +454,14 @@ jobs:
           set -euo pipefail
           check_absent() {
             crate="$1"
-            status="$(curl -L -sS -o response.json -w "%{http_code}" \
+            status="$(curl -L -sS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-all-errors \
+              -o response.json \
+              -w "%{http_code}" \
               -H "User-Agent: alessandrobologna/s3-unspool release workflow" \
               "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
             if [ "$status" = "200" ]; then
@@ -498,7 +499,14 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in {1..30}; do
-            status="$(curl -L -sS -o response.json -w "%{http_code}" \
+            status="$(curl -L -sS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-all-errors \
+              -o response.json \
+              -w "%{http_code}" \
               -H "User-Agent: alessandrobologna/s3-unspool release workflow" \
               "https://crates.io/api/v1/crates/s3-unspool/${VERSION}")"
             if [ "$status" = "200" ]; then

--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -136,6 +136,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$PUBLISHING" = "true" ]; then
+            # For GitHub hosting, cargo-dist create renders release hosting URLs;
+            # the actual GitHub Release is created later in the announce job.
             dist host --steps=create --tag="$TAG" --output-format=json > plan-dist-manifest.json
           else
             dist plan --output-format=json > plan-dist-manifest.json
@@ -361,12 +363,12 @@ jobs:
           path: target/distrib/
           merge-multiple: true
 
-      - name: Stage artifacts
+      - name: Render release metadata
         id: host
         shell: bash
         run: |
           set -euo pipefail
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=check --output-format=json > dist-manifest.json
           cat dist-manifest.json
           manifest="$(jq -c '.' dist-manifest.json)"
           echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -45,6 +45,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
       - name: Read and validate release version
         id: release
         shell: bash
@@ -158,6 +163,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Install Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
 
       - name: Install Rust toolchain
         shell: bash

--- a/.github/workflows/s3-unspool-ci.yml
+++ b/.github/workflows/s3-unspool-ci.yml
@@ -10,6 +10,9 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/s3-unspool/**"
+      - "crates/s3-unspool-cli/**"
+      - "dist-workspace.toml"
+      - "rust-toolchain.toml"
 
 permissions: {}
 
@@ -46,11 +49,20 @@ jobs:
       - name: Run crate tests
         run: cargo test -p s3-unspool
 
+      - name: Run CLI tests
+        run: cargo test -p s3-unspool-cli
+
       - name: Run clippy
         run: cargo clippy -p s3-unspool --all-targets -- -D warnings
+
+      - name: Run CLI clippy
+        run: cargo clippy -p s3-unspool-cli --all-targets -- -D warnings
 
       - name: Build crate documentation
         run: cargo doc -p s3-unspool --no-deps
 
       - name: Verify crate package
         run: cargo package -p s3-unspool
+
+      - name: Verify CLI package manifest
+        run: cargo package -p s3-unspool-cli --list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3-unspool"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "s3-unspool-cli"
-version = "0.1.0"
+version = "0.1.0-beta.3"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ http-body-util = "0.1.3"
 lambda_runtime = "1.1.3"
 libc = "0.2.186"
 md5 = { package = "md-5", version = "0.11.0" }
-s3-unspool = { path = "crates/s3-unspool" }
+s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.3" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 terminal_size = "0.4.4"
@@ -40,3 +40,7 @@ tokio = { version = "1.52.1", features = ["full"] }
 tokio-util = { version = "0.7.18", features = ["io"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
+
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/README.md
+++ b/README.md
@@ -91,8 +91,19 @@ cargo add s3-unspool
 ```
 
 The published crate contains the library API. The CLI and Lambda code in this
-repository are development and benchmark tools, not separate published
-artifacts.
+repository are packaged separately: the CLI is available as the pre-release
+`s3-unspool-cli` crate, and the Lambda package remains a development and
+benchmark tool.
+
+Install the CLI with `cargo-binstall` when prebuilt GitHub Release artifacts are
+available:
+
+```sh
+cargo binstall s3-unspool-cli --version 0.1.0-beta.3
+```
+
+The CLI crate name is `s3-unspool-cli`, but the installed command is
+`s3-unspool`.
 
 ## Quick Start
 
@@ -337,8 +348,12 @@ and upload sources cannot contain a file at that path.
 
 ## Command-Line Testing
 
-The repository includes a CLI for trying the same zip and unzip flows from a
-terminal. Build it from a checkout:
+The CLI runs the same zip and unzip flows from a terminal. Install the
+pre-release binary with `cargo-binstall`, or build it from a checkout:
+
+```sh
+cargo binstall s3-unspool-cli --version 0.1.0-beta.3
+```
 
 ```sh
 cargo build --release -p s3-unspool-cli --bin s3-unspool
@@ -611,13 +626,13 @@ with a known mix of file sizes and compressibility.
 | Path | Purpose |
 | --- | --- |
 | `crates/s3-unspool` | Published Rust library crate |
-| `crates/s3-unspool-cli` | Repository CLI for testing and reports |
+| `crates/s3-unspool-cli` | Published pre-release CLI crate; installs `s3-unspool` |
 | `lambda/s3-unspool-lambda` | SAM/Cargo Lambda benchmark harness |
 | `scripts/` | Fixture generation and benchmark helpers |
 | `docs/` | Architecture notes and generated benchmark chart assets |
 
-The CLI and Lambda packages are repository tools. The published crate is
-`s3-unspool`.
+The Lambda package is repository tooling. The published packages are
+`s3-unspool` for the library and `s3-unspool-cli` for the command-line binary.
 
 ## Versioning
 
@@ -626,16 +641,16 @@ identifiers such as `0.1.0-alpha.1`, `0.1.0-beta.1`, or `0.1.0-rc.1`.
 Consumers opt into a pre-release explicitly:
 
 ```sh
-cargo add s3-unspool@0.1.0-beta.2
+cargo add s3-unspool@0.1.0-beta.3
 ```
 
 Releases are published by the manual `Publish s3-unspool` GitHub Actions
-workflow. The workflow reads the version from `crates/s3-unspool/Cargo.toml`,
-publishes with crates.io Trusted Publishing, and creates the matching
-`v<version>` git tag only after `cargo publish` succeeds. Configure the
-`s3-unspool` crate on crates.io to trust this repository's
-`publish-s3-unspool.yml` workflow and the `release` GitHub environment before
-running it.
+workflow. The workflow keeps `s3-unspool` and `s3-unspool-cli` in lockstep,
+builds `cargo-dist` CLI archives for GitHub Releases, publishes the library
+crate first, waits for registry propagation, publishes the CLI crate, and only
+then creates the matching `v<version>` GitHub Release. Configure both crates on
+crates.io to trust this repository's `publish-s3-unspool.yml` workflow and the
+`release` GitHub environment before running it.
 
 ## Assumptions and Limits
 

--- a/crates/s3-unspool-cli/Cargo.toml
+++ b/crates/s3-unspool-cli/Cargo.toml
@@ -1,16 +1,28 @@
 [package]
 name = "s3-unspool-cli"
-version = "0.1.0"
+version = "0.1.0-beta.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+description = "Command-line ZIP sync and extraction tool for S3 prefixes."
 license.workspace = true
+readme = "../../README.md"
 repository.workspace = true
-publish = false
+keywords = ["aws", "s3", "zip", "archive", "cli"]
+categories = ["command-line-utilities", "compression", "filesystem"]
 
 [[bin]]
 name = "s3-unspool"
 path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.xz"
+pkg-fmt = "txz"
+bin-dir = "{ bin }{ binary-ext }"
+
+[package.metadata.binstall.overrides.'cfg(windows)']
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
+pkg-fmt = "zip"
 
 [dependencies]
 aws-config.workspace = true

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,0 +1,19 @@
+[workspace]
+members = ["cargo:."]
+
+[dist]
+allow-dirty = ["ci"]
+cargo-dist-version = "0.31.0"
+ci = "github"
+installers = []
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-pc-windows-msvc"]
+hosting = "github"
+packages = ["s3-unspool-cli"]
+github-release = "announce"
+publish-prereleases = true
+pr-run-mode = "plan"
+
+[dist.github-action-commits]
+"actions/checkout" = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+"actions/upload-artifact" = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
+"actions/download-artifact" = "37930b1c2abaa49bbe596cd826c3c89aef350131"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- promote `s3-unspool-cli` to a lockstep pre-release package at `0.1.0-beta.3`
- add cargo-dist configuration for Linux x64, macOS Apple Silicon, and Windows x64 GitHub Release assets
- rework the manual publish workflow to build artifacts first, publish the library crate, wait for propagation, publish the CLI crate, then create the GitHub prerelease
- document `cargo binstall s3-unspool-cli --version 0.1.0-beta.3`

Closes #9.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p s3-unspool`
- `cargo test -p s3-unspool-cli`
- `cargo clippy -p s3-unspool --all-targets -- -D warnings`
- `cargo clippy -p s3-unspool-cli --all-targets -- -D warnings`
- `cargo doc -p s3-unspool --no-deps`
- `cargo package -p s3-unspool --allow-dirty`
- `cargo publish -p s3-unspool --dry-run --allow-dirty`
- `cargo package -p s3-unspool-cli --allow-dirty --list`
- `dist generate --check`
- `dist plan --tag v0.1.0-beta.3`
- workflow YAML parse, `actionlint`, extracted `bash -n`/`shellcheck`, and `git diff --check`

`cargo publish -p s3-unspool-cli --dry-run` cannot pass locally until `s3-unspool 0.1.0-beta.3` exists on crates.io; the publish workflow runs it after publishing and waiting for the library crate to propagate.
