### PR TITLE
zip: add zstd compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,8 @@ checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1821,6 +1823,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -2936,3 +2944,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ http-body-util = "0.1.3"
 lambda_runtime = "1.1.3"
 libc = "0.2.186"
 md5 = { package = "md-5", version = "0.11.0" }
-s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.3" }
+s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.3", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 terminal_size = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Use `s3-unspool` when you need to deploy or synchronize many files from a ZIP
 archive already stored in S3, especially when repeated runs should touch only
 changed files.
 
-It is not a general archive library. ZIP extraction currently supports Stored
-and Deflate entries, destination writes are single `PutObject` requests, and
-destination ETags are expected to be single-part MD5 ETags.
+It is not a general archive library. ZIP extraction currently supports Stored,
+Deflate, and Zstandard method 93 entries when default features are enabled;
+destination writes are single `PutObject` requests, and destination ETags are
+expected to be single-part MD5 ETags.
 
 ## Lambda Benchmark Snapshot
 
@@ -179,6 +180,10 @@ async fn main() -> s3_unspool::Result<()> {
 
 `UploadOptions::include_catalog` is `true` by default. Set it to `false` only
 when you need a plain ZIP without the update-skip catalog.
+Regular file entries use Deflate by default. Build with default features and set
+`UploadOptions::compression = ZipCompression::Zstd` to generate Zstandard
+method 93 entries; use `default-features = false` to compile without Zstd
+support.
 
 ### Upload an S3 Prefix as a Cataloged ZIP
 
@@ -399,6 +404,8 @@ Useful zip options:
 - `--dry-run`: inspect the source tree and report what would be archived
   without creating a local ZIP or uploading an S3 object.
 - `--no-catalog`: create a plain ZIP without `.s3-unspool/catalog.v1.json`.
+- `--compression deflate|zstd`: choose the compression method for regular file
+  entries. Zstd writes ZIP method 93 and may not open in OS-native ZIP tools.
 - `--report`: add a formatted zip report to the CLI transcript.
 - `--report=PATH`: write the JSON zip report to a file.
 
@@ -669,7 +676,9 @@ crates.io to trust this repository's `publish-s3-unspool.yml` workflow and the
 ## Assumptions and Limits
 
 - The crate is built for Rust 1.95 and edition 2024.
-- ZIP extraction supports Stored and Deflate entries.
+- ZIP extraction supports Stored, Deflate, and Zstandard method 93 entries when
+  default features are enabled. Build with `default-features = false` to omit
+  Zstd support.
 - Local zip sources must be local directories and include regular files plus
   empty directories recursively.
 - S3-prefix zip sources include regular objects and zero-byte trailing-slash

--- a/crates/s3-unspool-cli/Cargo.toml
+++ b/crates/s3-unspool-cli/Cargo.toml
@@ -24,6 +24,10 @@ bin-dir = "{ bin }{ binary-ext }"
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
 pkg-fmt = "zip"
 
+[features]
+default = ["zstd"]
+zstd = ["s3-unspool/zstd"]
+
 [dependencies]
 aws-config.workspace = true
 aws-sdk-s3.workspace = true

--- a/crates/s3-unspool-cli/src/main.rs
+++ b/crates/s3-unspool-cli/src/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
-use std::result::Result;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,7 +9,7 @@ use std::time::{Duration, Instant};
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
-use s3_unspool::*;
+use s3_unspool as unspool;
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
 
@@ -101,53 +100,57 @@ async fn run_unzip(
     let report = match (source, destination) {
         (ZipSource::S3(source), TreeDestination::S3(destination)) => {
             let client = s3_client().await;
-            let mut options = SyncOptions::new(source, destination);
+            let mut options = unspool::SyncOptions::new(source, destination);
             options.concurrency = concurrency;
             options.delete_extra = delete_extra;
             options.collect_diagnostics = diagnostics;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
             if dry_run {
-                UnzipCommandReport::DryRun(dry_run_sync_zip_to_s3(&client, options).await?)
+                UnzipCommandReport::DryRun(unspool::dry_run_sync_zip_to_s3(&client, options).await?)
             } else {
-                UnzipCommandReport::S3(sync_zip_to_s3(&client, options).await?)
+                UnzipCommandReport::S3(unspool::sync_zip_to_s3(&client, options).await?)
             }
         }
         (ZipSource::Local(source_zip), TreeDestination::S3(destination)) => {
             let client = s3_client().await;
-            let mut options = LocalZipSyncOptions::new(source_zip, destination);
+            let mut options = unspool::LocalZipSyncOptions::new(source_zip, destination);
             options.concurrency = concurrency;
             options.delete_extra = delete_extra;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
             if dry_run {
-                UnzipCommandReport::DryRun(dry_run_unzip_file_to_s3(&client, options).await?)
+                UnzipCommandReport::DryRun(
+                    unspool::dry_run_unzip_file_to_s3(&client, options).await?,
+                )
             } else {
-                UnzipCommandReport::LocalZipToS3(unzip_file_to_s3(&client, options).await?)
+                UnzipCommandReport::LocalZipToS3(unspool::unzip_file_to_s3(&client, options).await?)
             }
         }
         (ZipSource::S3(source), TreeDestination::Local(destination_dir)) => {
             let client = s3_client().await;
-            let mut options = S3ZipLocalUnzipOptions::new(source, destination_dir);
+            let mut options = unspool::S3ZipLocalUnzipOptions::new(source, destination_dir);
             options.concurrency = concurrency;
             options.collect_diagnostics = diagnostics;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
             if dry_run {
-                UnzipCommandReport::DryRun(dry_run_unzip_s3_zip_to_local(&client, options).await?)
+                UnzipCommandReport::DryRun(
+                    unspool::dry_run_unzip_s3_zip_to_local(&client, options).await?,
+                )
             } else {
-                UnzipCommandReport::Local(unzip_s3_zip_to_local(&client, options).await?)
+                UnzipCommandReport::Local(unspool::unzip_s3_zip_to_local(&client, options).await?)
             }
         }
         (ZipSource::Local(source_zip), TreeDestination::Local(destination_dir)) => {
-            let mut options = LocalUnzipOptions::new(source_zip, destination_dir);
+            let mut options = unspool::LocalUnzipOptions::new(source_zip, destination_dir);
             options.concurrency = concurrency;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
             if dry_run {
-                UnzipCommandReport::DryRun(dry_run_unzip_file_to_local(options).await?)
+                UnzipCommandReport::DryRun(unspool::dry_run_unzip_file_to_local(options).await?)
             } else {
-                UnzipCommandReport::Local(unzip_file_to_local(options).await?)
+                UnzipCommandReport::Local(unspool::unzip_file_to_local(options).await?)
             }
         }
     };
@@ -200,7 +203,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
 
     let progress_detail = ActivityDetail::default();
     let progress_sink = progress_detail.clone();
-    let progress = UploadProgressHandler::new(move |progress| {
+    let progress = unspool::UploadProgressHandler::new(move |progress| {
         progress_sink.set(upload_progress_state(&progress));
     });
     let activity = output.start_activity(
@@ -210,50 +213,58 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
     let zip_started = Instant::now();
     let report = match (source, destination) {
         (TreeSource::Local(source_dir), ZipDestination::S3(destination)) => {
-            let mut options = UploadOptions::new(source_dir, destination);
+            let mut options = unspool::UploadOptions::new(source_dir, destination);
             options.include_catalog = include_catalog;
             options.compression = compression;
             if dry_run {
-                ZipCommandReport::DryRun(dry_run_upload_directory_zip_to_s3(options).await?)
+                ZipCommandReport::DryRun(
+                    unspool::dry_run_upload_directory_zip_to_s3(options).await?,
+                )
             } else {
                 let client = s3_client().await;
                 options.progress = Some(progress);
-                ZipCommandReport::Upload(upload_directory_zip_to_s3(&client, options).await?)
+                ZipCommandReport::Upload(
+                    unspool::upload_directory_zip_to_s3(&client, options).await?,
+                )
             }
         }
         (TreeSource::Local(source_dir), ZipDestination::Local(destination_zip)) => {
-            let mut options = LocalZipOptions::new(source_dir, destination_zip);
+            let mut options = unspool::LocalZipOptions::new(source_dir, destination_zip);
             options.include_catalog = include_catalog;
             options.compression = compression;
             if dry_run {
-                ZipCommandReport::DryRun(dry_run_zip_directory_to_file(options).await?)
+                ZipCommandReport::DryRun(unspool::dry_run_zip_directory_to_file(options).await?)
             } else {
                 options.progress = Some(progress);
-                ZipCommandReport::Local(zip_directory_to_file(options).await?)
+                ZipCommandReport::Local(unspool::zip_directory_to_file(options).await?)
             }
         }
         (TreeSource::S3(source), ZipDestination::S3(destination)) => {
             let client = s3_client().await;
-            let mut options = S3PrefixUploadOptions::new(source, destination);
+            let mut options = unspool::S3PrefixUploadOptions::new(source, destination);
             options.include_catalog = include_catalog;
             options.compression = compression;
             if dry_run {
-                ZipCommandReport::DryRun(dry_run_zip_s3_prefix_to_s3(&client, options).await?)
+                ZipCommandReport::DryRun(
+                    unspool::dry_run_zip_s3_prefix_to_s3(&client, options).await?,
+                )
             } else {
                 options.progress = Some(progress);
-                ZipCommandReport::S3Prefix(zip_s3_prefix_to_s3(&client, options).await?)
+                ZipCommandReport::S3Prefix(unspool::zip_s3_prefix_to_s3(&client, options).await?)
             }
         }
         (TreeSource::S3(source), ZipDestination::Local(destination_zip)) => {
             let client = s3_client().await;
-            let mut options = S3PrefixLocalZipOptions::new(source, destination_zip);
+            let mut options = unspool::S3PrefixLocalZipOptions::new(source, destination_zip);
             options.include_catalog = include_catalog;
             options.compression = compression;
             if dry_run {
-                ZipCommandReport::DryRun(dry_run_zip_s3_prefix_to_file(&client, options).await?)
+                ZipCommandReport::DryRun(
+                    unspool::dry_run_zip_s3_prefix_to_file(&client, options).await?,
+                )
             } else {
                 options.progress = Some(progress);
-                ZipCommandReport::Local(zip_s3_prefix_to_file(&client, options).await?)
+                ZipCommandReport::Local(unspool::zip_s3_prefix_to_file(&client, options).await?)
             }
         }
     };
@@ -296,7 +307,7 @@ impl ReportDestination {
 
 enum TreeSource {
     Local(PathBuf),
-    S3(S3Prefix),
+    S3(unspool::S3Prefix),
 }
 
 impl TreeSource {
@@ -310,7 +321,7 @@ impl TreeSource {
 
 enum TreeDestination {
     Local(PathBuf),
-    S3(S3Prefix),
+    S3(unspool::S3Prefix),
 }
 
 impl TreeDestination {
@@ -324,7 +335,7 @@ impl TreeDestination {
 
 enum ZipSource {
     Local(PathBuf),
-    S3(S3Object),
+    S3(unspool::S3Object),
 }
 
 impl ZipSource {
@@ -338,7 +349,7 @@ impl ZipSource {
 
 enum ZipDestination {
     Local(PathBuf),
-    S3(S3Object),
+    S3(unspool::S3Object),
 }
 
 impl ZipDestination {
@@ -353,7 +364,7 @@ impl ZipDestination {
 fn parse_tree_source(value: &str) -> Result<TreeSource, Box<dyn std::error::Error>> {
     reject_file_uri(value)?;
     if value.starts_with("s3://") {
-        Ok(TreeSource::S3(S3Prefix::parse(value)?))
+        Ok(TreeSource::S3(unspool::S3Prefix::parse(value)?))
     } else {
         Ok(TreeSource::Local(PathBuf::from(value)))
     }
@@ -362,7 +373,7 @@ fn parse_tree_source(value: &str) -> Result<TreeSource, Box<dyn std::error::Erro
 fn parse_tree_destination(value: &str) -> Result<TreeDestination, Box<dyn std::error::Error>> {
     reject_file_uri(value)?;
     if value.starts_with("s3://") {
-        Ok(TreeDestination::S3(S3Prefix::parse(value)?))
+        Ok(TreeDestination::S3(unspool::S3Prefix::parse(value)?))
     } else {
         Ok(TreeDestination::Local(PathBuf::from(value)))
     }
@@ -371,7 +382,7 @@ fn parse_tree_destination(value: &str) -> Result<TreeDestination, Box<dyn std::e
 fn parse_zip_source(value: &str) -> Result<ZipSource, Box<dyn std::error::Error>> {
     reject_file_uri(value)?;
     if value.starts_with("s3://") {
-        Ok(ZipSource::S3(S3Object::parse(value)?))
+        Ok(ZipSource::S3(unspool::S3Object::parse(value)?))
     } else {
         Ok(ZipSource::Local(PathBuf::from(value)))
     }
@@ -380,7 +391,7 @@ fn parse_zip_source(value: &str) -> Result<ZipSource, Box<dyn std::error::Error>
 fn parse_zip_destination(value: &str) -> Result<ZipDestination, Box<dyn std::error::Error>> {
     reject_file_uri(value)?;
     if value.starts_with("s3://") {
-        Ok(ZipDestination::S3(S3Object::parse(value)?))
+        Ok(ZipDestination::S3(unspool::S3Object::parse(value)?))
     } else {
         Ok(ZipDestination::Local(PathBuf::from(value)))
     }
@@ -539,30 +550,40 @@ fn cli() -> Command {
                         .help("Do not include the embedded MD5 catalog in the ZIP")
                         .action(ArgAction::SetTrue),
                 )
-                .arg(
-                    Arg::new("compression")
-                        .long("compression")
-                        .value_name("METHOD")
-                        .help("Compression method for regular file entries")
-                        .value_parser(["deflate", "zstd"])
-                        .default_value("deflate"),
-                ),
+                .arg(zip_compression_arg()),
         )
+}
+
+fn zip_compression_arg() -> Arg {
+    let arg = Arg::new("compression")
+        .long("compression")
+        .value_name("METHOD")
+        .help("Compression method for regular file entries")
+        .default_value("deflate");
+
+    #[cfg(feature = "zstd")]
+    {
+        arg.value_parser(["deflate", "zstd"])
+    }
+    #[cfg(not(feature = "zstd"))]
+    {
+        arg.value_parser(["deflate"])
+    }
 }
 
 fn parse_zip_compression(
     matches: &ArgMatches,
-) -> Result<ZipCompression, Box<dyn std::error::Error>> {
+) -> Result<unspool::ZipCompression, Box<dyn std::error::Error>> {
     match matches
         .get_one::<String>("compression")
         .map(String::as_str)
         .unwrap_or("deflate")
     {
-        "deflate" => Ok(ZipCompression::Deflate),
+        "deflate" => Ok(unspool::ZipCompression::Deflate),
         "zstd" => {
             #[cfg(feature = "zstd")]
             {
-                Ok(ZipCompression::Zstd)
+                Ok(unspool::ZipCompression::Zstd)
             }
             #[cfg(not(feature = "zstd"))]
             {
@@ -885,10 +906,10 @@ impl Transcript {
 }
 
 enum ZipCommandReport {
-    Upload(UploadReport),
-    S3Prefix(S3PrefixUploadReport),
-    Local(LocalZipReport),
-    DryRun(ZipDryRunReport),
+    Upload(unspool::UploadReport),
+    S3Prefix(unspool::S3PrefixUploadReport),
+    Local(unspool::LocalZipReport),
+    DryRun(unspool::ZipDryRunReport),
 }
 
 impl ZipCommandReport {
@@ -969,10 +990,10 @@ impl ZipCommandReport {
 }
 
 enum UnzipCommandReport {
-    S3(SyncReport),
-    LocalZipToS3(LocalZipToS3Report),
-    Local(LocalUnzipReport),
-    DryRun(UnzipDryRunReport),
+    S3(unspool::SyncReport),
+    LocalZipToS3(unspool::LocalZipToS3Report),
+    Local(unspool::LocalUnzipReport),
+    DryRun(unspool::UnzipDryRunReport),
 }
 
 impl UnzipCommandReport {
@@ -997,7 +1018,7 @@ impl UnzipCommandReport {
         }
     }
 
-    fn summary(&self) -> Option<&SyncSummary> {
+    fn summary(&self) -> Option<&unspool::SyncSummary> {
         match self {
             Self::S3(report) => Some(&report.summary),
             Self::LocalZipToS3(report) => Some(&report.summary),
@@ -1006,7 +1027,7 @@ impl UnzipCommandReport {
         }
     }
 
-    fn dry_run_summary(&self) -> Option<&UnzipDryRunSummary> {
+    fn dry_run_summary(&self) -> Option<&unspool::UnzipDryRunSummary> {
         match self {
             Self::DryRun(report) => Some(&report.summary),
             Self::S3(_) | Self::LocalZipToS3(_) | Self::Local(_) => None,
@@ -1031,7 +1052,7 @@ impl UnzipCommandReport {
         }
     }
 
-    fn operations(&self) -> &[ObjectReport] {
+    fn operations(&self) -> &[unspool::ObjectReport] {
         match self {
             Self::S3(report) => &report.operations,
             Self::LocalZipToS3(report) => &report.operations,
@@ -1040,7 +1061,7 @@ impl UnzipCommandReport {
         }
     }
 
-    fn dry_run_operations(&self) -> &[DryRunObjectReport] {
+    fn dry_run_operations(&self) -> &[unspool::DryRunObjectReport] {
         match self {
             Self::DryRun(report) => &report.operations,
             Self::S3(_) | Self::LocalZipToS3(_) | Self::Local(_) => &[],
@@ -1203,7 +1224,7 @@ fn unzip_transcript(
 
 fn unzip_dry_run_transcript(
     report: &UnzipCommandReport,
-    summary: &UnzipDryRunSummary,
+    summary: &unspool::UnzipDryRunSummary,
     report_destination: &ReportDestination,
 ) -> Transcript {
     let mut details = if summary.would_upload_new == 0
@@ -1339,7 +1360,7 @@ fn unzip_report_details(report: &UnzipCommandReport) -> Vec<String> {
 
 fn unzip_dry_run_report_details(
     report: &UnzipCommandReport,
-    summary: &UnzipDryRunSummary,
+    summary: &unspool::UnzipDryRunSummary,
 ) -> Vec<String> {
     let mut details = vec![
         "Report:".to_string(),
@@ -1377,10 +1398,10 @@ fn unzip_dry_run_report_details(
     details
 }
 
-fn operation_report_details(operations: &[ObjectReport]) -> Vec<String> {
+fn operation_report_details(operations: &[unspool::ObjectReport]) -> Vec<String> {
     let noteworthy = operations
         .iter()
-        .filter(|operation| operation.status != OperationStatus::SkippedUnchanged)
+        .filter(|operation| operation.status != unspool::OperationStatus::SkippedUnchanged)
         .collect::<Vec<_>>();
 
     if noteworthy.is_empty() {
@@ -1404,10 +1425,10 @@ fn operation_report_details(operations: &[ObjectReport]) -> Vec<String> {
     details
 }
 
-fn dry_run_operation_report_details(operations: &[DryRunObjectReport]) -> Vec<String> {
+fn dry_run_operation_report_details(operations: &[unspool::DryRunObjectReport]) -> Vec<String> {
     let noteworthy = operations
         .iter()
-        .filter(|operation| operation.status != DryRunOperationStatus::SkippedUnchanged)
+        .filter(|operation| operation.status != unspool::DryRunOperationStatus::SkippedUnchanged)
         .collect::<Vec<_>>();
 
     if noteworthy.is_empty() {
@@ -1431,14 +1452,14 @@ fn dry_run_operation_report_details(operations: &[DryRunObjectReport]) -> Vec<St
     details
 }
 
-fn operation_report_line(operation: &ObjectReport) -> String {
+fn operation_report_line(operation: &unspool::ObjectReport) -> String {
     let status = match operation.status {
-        OperationStatus::UploadedNew => "uploaded new",
-        OperationStatus::UploadedChanged => "uploaded changed",
-        OperationStatus::SkippedUnchanged => "unchanged",
-        OperationStatus::ConditionalConflict => "conflict",
-        OperationStatus::DeletedExtra => "deleted extra",
-        OperationStatus::Error => "error",
+        unspool::OperationStatus::UploadedNew => "uploaded new",
+        unspool::OperationStatus::UploadedChanged => "uploaded changed",
+        unspool::OperationStatus::SkippedUnchanged => "unchanged",
+        unspool::OperationStatus::ConditionalConflict => "conflict",
+        unspool::OperationStatus::DeletedExtra => "deleted extra",
+        unspool::OperationStatus::Error => "error",
     };
     let size = operation
         .size
@@ -1453,13 +1474,13 @@ fn operation_report_line(operation: &ObjectReport) -> String {
     format!("{status}: {}{size}{message}", operation.key)
 }
 
-fn dry_run_operation_report_line(operation: &DryRunObjectReport) -> String {
+fn dry_run_operation_report_line(operation: &unspool::DryRunObjectReport) -> String {
     let status = match operation.status {
-        DryRunOperationStatus::WouldUploadNew => "would create",
-        DryRunOperationStatus::WouldUploadChanged => "would replace",
-        DryRunOperationStatus::SkippedUnchanged => "unchanged",
-        DryRunOperationStatus::WouldDeleteExtra => "would delete extra",
-        DryRunOperationStatus::Error => "error",
+        unspool::DryRunOperationStatus::WouldUploadNew => "would create",
+        unspool::DryRunOperationStatus::WouldUploadChanged => "would replace",
+        unspool::DryRunOperationStatus::SkippedUnchanged => "unchanged",
+        unspool::DryRunOperationStatus::WouldDeleteExtra => "would delete extra",
+        unspool::DryRunOperationStatus::Error => "error",
     };
     let size = operation
         .size
@@ -1474,7 +1495,7 @@ fn dry_run_operation_report_line(operation: &DryRunObjectReport) -> String {
     format!("{status}: {}{size}{message}", operation.key)
 }
 
-fn diagnostics_line(diagnostics: &SyncDiagnostics) -> String {
+fn diagnostics_line(diagnostics: &unspool::SyncDiagnostics) -> String {
     let mut line = format!(
         "Source: {} GET attempts, {} blocks fetched, {} waits, {:.2}x amplification",
         diagnostics.source.source_get_attempts,
@@ -1493,7 +1514,7 @@ fn diagnostics_line(diagnostics: &SyncDiagnostics) -> String {
     line
 }
 
-fn format_put_failure_codes(diagnostics: &PutDiagnostics) -> String {
+fn format_put_failure_codes(diagnostics: &unspool::PutDiagnostics) -> String {
     diagnostics
         .failures_by_error_code
         .iter()
@@ -1502,9 +1523,9 @@ fn format_put_failure_codes(diagnostics: &PutDiagnostics) -> String {
         .join(", ")
 }
 
-fn upload_progress_state(progress: &UploadProgress) -> ActivityProgress {
+fn upload_progress_state(progress: &unspool::UploadProgress) -> ActivityProgress {
     match progress {
-        UploadProgress::Planned {
+        unspool::UploadProgress::Planned {
             total_files,
             total_bytes,
         } => ActivityProgress {
@@ -1514,7 +1535,7 @@ fn upload_progress_state(progress: &UploadProgress) -> ActivityProgress {
             processed_bytes: 0,
             total_bytes: *total_bytes,
         },
-        UploadProgress::FileStarted {
+        unspool::UploadProgress::FileStarted {
             current_file,
             total_files,
             processed_files,
@@ -1528,7 +1549,7 @@ fn upload_progress_state(progress: &UploadProgress) -> ActivityProgress {
             processed_bytes: *processed_bytes,
             total_bytes: *total_bytes,
         },
-        UploadProgress::FileProgress {
+        unspool::UploadProgress::FileProgress {
             current_file,
             total_files,
             processed_files,
@@ -1542,7 +1563,7 @@ fn upload_progress_state(progress: &UploadProgress) -> ActivityProgress {
             processed_bytes: *processed_bytes,
             total_bytes: *total_bytes,
         },
-        UploadProgress::FileFinished {
+        unspool::UploadProgress::FileFinished {
             processed_files,
             total_files,
             processed_bytes,
@@ -1555,7 +1576,7 @@ fn upload_progress_state(progress: &UploadProgress) -> ActivityProgress {
             processed_bytes: *processed_bytes,
             total_bytes: *total_bytes,
         },
-        UploadProgress::Finished {
+        unspool::UploadProgress::Finished {
             total_files,
             total_bytes,
         } => ActivityProgress {
@@ -1768,10 +1789,6 @@ fn format_upload_speed(bytes: u64, elapsed: Duration) -> String {
 
 #[cfg(test)]
 mod tests {
-    use s3_unspool::{
-        PutRetryDiagnostics, RetryJitter, SourceDiagnostics, SyncDiagnostics, SyncSummary,
-    };
-
     use super::*;
 
     #[test]
@@ -1851,6 +1868,7 @@ mod tests {
         assert!(upload.get_flag("no-catalog"));
     }
 
+    #[cfg(feature = "zstd")]
     #[test]
     fn parses_zip_compression() {
         let matches = cli()
@@ -1871,15 +1889,27 @@ mod tests {
             upload.get_one::<String>("compression").map(String::as_str),
             Some("zstd")
         );
-        #[cfg(feature = "zstd")]
-        assert_eq!(parse_zip_compression(upload).unwrap(), ZipCompression::Zstd);
-        #[cfg(not(feature = "zstd"))]
-        assert!(
-            parse_zip_compression(upload)
-                .unwrap_err()
-                .to_string()
-                .contains("requires the s3-unspool-cli `zstd` feature")
+        assert_eq!(
+            parse_zip_compression(upload).unwrap(),
+            unspool::ZipCompression::Zstd
         );
+    }
+
+    #[cfg(not(feature = "zstd"))]
+    #[test]
+    fn rejects_zstd_zip_compression_without_feature() {
+        let error = cli()
+            .try_get_matches_from([
+                "s3-unspool",
+                "zip",
+                "--compression",
+                "zstd",
+                "/tmp/site",
+                "s3://destination-bucket/site.zip",
+            ])
+            .unwrap_err();
+
+        assert!(error.to_string().contains("possible values: deflate"));
     }
 
     #[test]
@@ -2152,9 +2182,9 @@ mod tests {
 
     #[test]
     fn renders_zip_transcript() {
-        let report = UploadReport {
+        let report = unspool::UploadReport {
             source_dir: "./site".to_string(),
-            destination: S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
             files: 2,
             directories: 0,
             include_catalog: true,
@@ -2176,9 +2206,9 @@ mod tests {
 
     #[test]
     fn renders_zip_transcript_with_human_report() {
-        let report = UploadReport {
+        let report = unspool::UploadReport {
             source_dir: "./site".to_string(),
-            destination: S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
             files: 2,
             directories: 1,
             include_catalog: true,
@@ -2200,7 +2230,7 @@ mod tests {
 
     #[test]
     fn renders_zip_dry_run_transcript() {
-        let report = ZipDryRunReport {
+        let report = unspool::ZipDryRunReport {
             source: "./site".to_string(),
             destination: "s3://bucket/site.zip".to_string(),
             files: 2,
@@ -2224,14 +2254,14 @@ mod tests {
 
     #[test]
     fn renders_up_to_date_unzip_transcript() {
-        let report = SyncReport {
-            source: S3Object::parse("s3://bucket/site.zip").unwrap(),
-            destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
-            summary: SyncSummary {
+        let report = unspool::SyncReport {
+            source: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Prefix::parse("s3://bucket/www/").unwrap(),
+            summary: unspool::SyncSummary {
                 zip_files: 10,
                 destination_objects: 10,
                 skipped_unchanged: 10,
-                ..SyncSummary::default()
+                ..unspool::SyncSummary::default()
             },
             diagnostics: None,
             operations: Vec::new(),
@@ -2248,34 +2278,34 @@ mod tests {
 
     #[test]
     fn renders_changed_unzip_transcript_with_diagnostics() {
-        let report = SyncReport {
-            source: S3Object::parse("s3://bucket/site.zip").unwrap(),
-            destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
-            summary: SyncSummary {
+        let report = unspool::SyncReport {
+            source: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Prefix::parse("s3://bucket/www/").unwrap(),
+            summary: unspool::SyncSummary {
                 zip_files: 10,
                 destination_objects: 12,
                 uploaded_new: 1,
                 uploaded_changed: 2,
                 skipped_unchanged: 7,
                 deleted_extra: 1,
-                ..SyncSummary::default()
+                ..unspool::SyncSummary::default()
             },
-            diagnostics: Some(SyncDiagnostics {
+            diagnostics: Some(unspool::SyncDiagnostics {
                 concurrency: 64,
                 put_concurrency: 8,
-                put_retry: PutRetryDiagnostics {
+                put_retry: unspool::PutRetryDiagnostics {
                     max_attempts: 6,
                     base_delay_ms: 250,
                     max_delay_ms: 5_000,
                     slowdown_base_delay_ms: 1_000,
                     slowdown_max_delay_ms: 30_000,
-                    jitter: RetryJitter::Full,
+                    jitter: unspool::RetryJitter::Full,
                 },
                 source_block_size: 8192,
                 source_block_merge_gap: 1024,
                 source_get_concurrency: 4,
                 source_window_capacity: 4096,
-                source: SourceDiagnostics {
+                source: unspool::SourceDiagnostics {
                     source_zip_bytes: 100,
                     planned_entries: 3,
                     planned_blocks: 2,
@@ -2297,7 +2327,7 @@ mod tests {
                     block_refetches: 0,
                     active_gets_high_water: 2,
                 },
-                put: PutDiagnostics::default(),
+                put: unspool::PutDiagnostics::default(),
             }),
             operations: Vec::new(),
         };
@@ -2315,10 +2345,10 @@ mod tests {
 
     #[test]
     fn renders_unzip_dry_run_transcript_with_human_report() {
-        let report = UnzipDryRunReport {
+        let report = unspool::UnzipDryRunReport {
             source_zip: "s3://bucket/site.zip".to_string(),
             destination: "s3://bucket/www/".to_string(),
-            summary: UnzipDryRunSummary {
+            summary: unspool::UnzipDryRunSummary {
                 zip_files: 3,
                 destination_objects: 4,
                 would_upload_new: 1,
@@ -2329,8 +2359,8 @@ mod tests {
             },
             diagnostics: None,
             operations: vec![
-                DryRunObjectReport {
-                    status: DryRunOperationStatus::WouldUploadNew,
+                unspool::DryRunObjectReport {
+                    status: unspool::DryRunOperationStatus::WouldUploadNew,
                     key: "www/a.txt".to_string(),
                     zip_path: Some("a.txt".to_string()),
                     size: Some(10),
@@ -2338,8 +2368,8 @@ mod tests {
                     destination_etag: None,
                     message: None,
                 },
-                DryRunObjectReport {
-                    status: DryRunOperationStatus::WouldUploadChanged,
+                unspool::DryRunObjectReport {
+                    status: unspool::DryRunOperationStatus::WouldUploadChanged,
                     key: "www/b.txt".to_string(),
                     zip_path: Some("b.txt".to_string()),
                     size: Some(20),
@@ -2347,8 +2377,8 @@ mod tests {
                     destination_etag: Some("\"etag\"".to_string()),
                     message: None,
                 },
-                DryRunObjectReport {
-                    status: DryRunOperationStatus::SkippedUnchanged,
+                unspool::DryRunObjectReport {
+                    status: unspool::DryRunOperationStatus::SkippedUnchanged,
                     key: "www/c.txt".to_string(),
                     zip_path: Some("c.txt".to_string()),
                     size: Some(30),
@@ -2356,8 +2386,8 @@ mod tests {
                     destination_etag: Some("\"same\"".to_string()),
                     message: None,
                 },
-                DryRunObjectReport {
-                    status: DryRunOperationStatus::WouldDeleteExtra,
+                unspool::DryRunObjectReport {
+                    status: unspool::DryRunOperationStatus::WouldDeleteExtra,
                     key: "www/old.txt".to_string(),
                     zip_path: None,
                     size: None,
@@ -2381,21 +2411,21 @@ mod tests {
 
     #[test]
     fn renders_unzip_transcript_with_human_report() {
-        let report = SyncReport {
-            source: S3Object::parse("s3://bucket/site.zip").unwrap(),
-            destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
-            summary: SyncSummary {
+        let report = unspool::SyncReport {
+            source: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Prefix::parse("s3://bucket/www/").unwrap(),
+            summary: unspool::SyncSummary {
                 zip_files: 3,
                 destination_objects: 2,
                 uploaded_new: 1,
                 uploaded_changed: 1,
                 skipped_unchanged: 1,
-                ..SyncSummary::default()
+                ..unspool::SyncSummary::default()
             },
             diagnostics: None,
             operations: vec![
-                ObjectReport {
-                    status: OperationStatus::UploadedNew,
+                unspool::ObjectReport {
+                    status: unspool::OperationStatus::UploadedNew,
                     key: "www/a.txt".to_string(),
                     zip_path: Some("a.txt".to_string()),
                     size: Some(10),
@@ -2403,8 +2433,8 @@ mod tests {
                     destination_etag: None,
                     message: None,
                 },
-                ObjectReport {
-                    status: OperationStatus::UploadedChanged,
+                unspool::ObjectReport {
+                    status: unspool::OperationStatus::UploadedChanged,
                     key: "www/b.txt".to_string(),
                     zip_path: Some("b.txt".to_string()),
                     size: Some(20),
@@ -2412,8 +2442,8 @@ mod tests {
                     destination_etag: Some("old".to_string()),
                     message: None,
                 },
-                ObjectReport {
-                    status: OperationStatus::SkippedUnchanged,
+                unspool::ObjectReport {
+                    status: unspool::OperationStatus::SkippedUnchanged,
                     key: "www/c.txt".to_string(),
                     zip_path: Some("c.txt".to_string()),
                     size: Some(30),
@@ -2435,16 +2465,16 @@ mod tests {
 
     #[test]
     fn renders_conflict_unzip_transcript() {
-        let report = SyncReport {
-            source: S3Object::parse("s3://bucket/site.zip").unwrap(),
-            destination: S3Prefix::parse("s3://bucket/www/").unwrap(),
-            summary: SyncSummary {
+        let report = unspool::SyncReport {
+            source: unspool::S3Object::parse("s3://bucket/site.zip").unwrap(),
+            destination: unspool::S3Prefix::parse("s3://bucket/www/").unwrap(),
+            summary: unspool::SyncSummary {
                 zip_files: 3,
                 destination_objects: 3,
                 uploaded_changed: 1,
                 skipped_unchanged: 1,
                 conditional_conflicts: 1,
-                ..SyncSummary::default()
+                ..unspool::SyncSummary::default()
             },
             diagnostics: None,
             operations: Vec::new(),
@@ -2540,7 +2570,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::Planned {
+                &upload_progress_state(&unspool::UploadProgress::Planned {
                     total_files: 10,
                     total_bytes: 100,
                 }),
@@ -2552,7 +2582,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::FileFinished {
+                &upload_progress_state(&unspool::UploadProgress::FileFinished {
                     processed_files: 3,
                     total_files: 10,
                     processed_bytes: 30,
@@ -2567,7 +2597,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::FileStarted {
+                &upload_progress_state(&unspool::UploadProgress::FileStarted {
                     current_file: 4,
                     total_files: 10,
                     processed_files: 3,
@@ -2583,7 +2613,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::FileProgress {
+                &upload_progress_state(&unspool::UploadProgress::FileProgress {
                     current_file: 4,
                     total_files: 10,
                     processed_files: 3,
@@ -2599,7 +2629,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::Finished {
+                &upload_progress_state(&unspool::UploadProgress::Finished {
                     total_files: 10,
                     total_bytes: 100,
                 }),
@@ -2613,7 +2643,7 @@ mod tests {
     #[test]
     fn maps_upload_progress_events_to_activity_state() {
         assert_eq!(
-            upload_progress_state(&UploadProgress::Planned {
+            upload_progress_state(&unspool::UploadProgress::Planned {
                 total_files: 10,
                 total_bytes: 100,
             }),
@@ -2626,7 +2656,7 @@ mod tests {
             }
         );
         assert_eq!(
-            upload_progress_state(&UploadProgress::FileFinished {
+            upload_progress_state(&unspool::UploadProgress::FileFinished {
                 processed_files: 3,
                 total_files: 10,
                 processed_bytes: 30,
@@ -2642,7 +2672,7 @@ mod tests {
             }
         );
         assert_eq!(
-            upload_progress_state(&UploadProgress::FileStarted {
+            upload_progress_state(&unspool::UploadProgress::FileStarted {
                 current_file: 4,
                 total_files: 10,
                 processed_files: 3,
@@ -2659,7 +2689,7 @@ mod tests {
             }
         );
         assert_eq!(
-            upload_progress_state(&UploadProgress::Finished {
+            upload_progress_state(&unspool::UploadProgress::Finished {
                 total_files: 10,
                 total_bytes: 100,
             }),
@@ -2705,7 +2735,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::FileProgress {
+                &upload_progress_state(&unspool::UploadProgress::FileProgress {
                     current_file: 4,
                     total_files: 10,
                     processed_files: 3,
@@ -2721,7 +2751,7 @@ mod tests {
         assert_eq!(
             render_progress(
                 Theme { color: false },
-                &upload_progress_state(&UploadProgress::FileProgress {
+                &upload_progress_state(&unspool::UploadProgress::FileProgress {
                     current_file: 4,
                     total_files: 10,
                     processed_files: 3,

--- a/crates/s3-unspool-cli/src/main.rs
+++ b/crates/s3-unspool-cli/src/main.rs
@@ -15,12 +15,12 @@ use s3_unspool::{
     OperationStatus, PutDiagnostics, S3Object, S3Prefix, S3PrefixLocalZipOptions,
     S3PrefixUploadOptions, S3PrefixUploadReport, S3ZipLocalUnzipOptions, SyncDiagnostics,
     SyncOptions, SyncReport, SyncSummary, UnzipDryRunReport, UnzipDryRunSummary, UploadOptions,
-    UploadProgress, UploadProgressHandler, UploadReport, ZipDryRunReport, dry_run_sync_zip_to_s3,
-    dry_run_unzip_file_to_local, dry_run_unzip_file_to_s3, dry_run_unzip_s3_zip_to_local,
-    dry_run_upload_directory_zip_to_s3, dry_run_zip_directory_to_file,
-    dry_run_zip_s3_prefix_to_file, dry_run_zip_s3_prefix_to_s3, sync_zip_to_s3,
-    unzip_file_to_local, unzip_file_to_s3, unzip_s3_zip_to_local, upload_directory_zip_to_s3,
-    zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
+    UploadProgress, UploadProgressHandler, UploadReport, ZipCompression, ZipDryRunReport,
+    dry_run_sync_zip_to_s3, dry_run_unzip_file_to_local, dry_run_unzip_file_to_s3,
+    dry_run_unzip_s3_zip_to_local, dry_run_upload_directory_zip_to_s3,
+    dry_run_zip_directory_to_file, dry_run_zip_s3_prefix_to_file, dry_run_zip_s3_prefix_to_s3,
+    sync_zip_to_s3, unzip_file_to_local, unzip_file_to_s3, unzip_s3_zip_to_local,
+    upload_directory_zip_to_s3, zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
@@ -187,6 +187,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
         .expect("required by clap");
     let dry_run = matches.get_flag("dry-run");
     let include_catalog = !matches.get_flag("no-catalog");
+    let compression = parse_zip_compression(matches)?;
     let report_destination = ReportDestination::from_cli_value(matches.get_one::<String>("report"));
     let source = parse_tree_source(source)?;
     let destination = parse_zip_destination(destination)?;
@@ -196,12 +197,13 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
         vec![
             format!("{} -> {}", source.display(), destination.display()),
             format!(
-                "catalog {}{}",
+                "catalog {}, compression {}{}",
                 if include_catalog {
                     "enabled"
                 } else {
                     "disabled"
                 },
+                compression.as_str(),
                 if dry_run { ", no changes" } else { "" }
             ),
         ],
@@ -221,6 +223,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
         (TreeSource::Local(source_dir), ZipDestination::S3(destination)) => {
             let mut options = UploadOptions::new(source_dir, destination);
             options.include_catalog = include_catalog;
+            options.compression = compression;
             if dry_run {
                 ZipCommandReport::DryRun(dry_run_upload_directory_zip_to_s3(options).await?)
             } else {
@@ -232,6 +235,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
         (TreeSource::Local(source_dir), ZipDestination::Local(destination_zip)) => {
             let mut options = LocalZipOptions::new(source_dir, destination_zip);
             options.include_catalog = include_catalog;
+            options.compression = compression;
             if dry_run {
                 ZipCommandReport::DryRun(dry_run_zip_directory_to_file(options).await?)
             } else {
@@ -243,6 +247,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
             let client = s3_client().await;
             let mut options = S3PrefixUploadOptions::new(source, destination);
             options.include_catalog = include_catalog;
+            options.compression = compression;
             if dry_run {
                 ZipCommandReport::DryRun(dry_run_zip_s3_prefix_to_s3(&client, options).await?)
             } else {
@@ -254,6 +259,7 @@ async fn run_zip(matches: &ArgMatches, output: &Output) -> Result<(), Box<dyn st
             let client = s3_client().await;
             let mut options = S3PrefixLocalZipOptions::new(source, destination_zip);
             options.include_catalog = include_catalog;
+            options.compression = compression;
             if dry_run {
                 ZipCommandReport::DryRun(dry_run_zip_s3_prefix_to_file(&client, options).await?)
             } else {
@@ -543,8 +549,39 @@ fn cli() -> Command {
                         .long("no-catalog")
                         .help("Do not include the embedded MD5 catalog in the ZIP")
                         .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("compression")
+                        .long("compression")
+                        .value_name("METHOD")
+                        .help("Compression method for regular file entries")
+                        .value_parser(["deflate", "zstd"])
+                        .default_value("deflate"),
                 ),
         )
+}
+
+fn parse_zip_compression(
+    matches: &ArgMatches,
+) -> Result<ZipCompression, Box<dyn std::error::Error>> {
+    match matches
+        .get_one::<String>("compression")
+        .map(String::as_str)
+        .unwrap_or("deflate")
+    {
+        "deflate" => Ok(ZipCompression::Deflate),
+        "zstd" => {
+            #[cfg(feature = "zstd")]
+            {
+                Ok(ZipCompression::Zstd)
+            }
+            #[cfg(not(feature = "zstd"))]
+            {
+                Err("zstd compression requires the s3-unspool-cli `zstd` feature".into())
+            }
+        }
+        other => Err(format!("unsupported ZIP compression method {other:?}").into()),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1823,6 +1860,37 @@ mod tests {
         };
         assert!(upload.get_flag("dry-run"));
         assert!(upload.get_flag("no-catalog"));
+    }
+
+    #[test]
+    fn parses_zip_compression() {
+        let matches = cli()
+            .try_get_matches_from([
+                "s3-unspool",
+                "zip",
+                "--compression",
+                "zstd",
+                "/tmp/site",
+                "s3://destination-bucket/site.zip",
+            ])
+            .unwrap();
+
+        let Some(("zip", upload)) = matches.subcommand() else {
+            panic!("expected zip subcommand");
+        };
+        assert_eq!(
+            upload.get_one::<String>("compression").map(String::as_str),
+            Some("zstd")
+        );
+        #[cfg(feature = "zstd")]
+        assert_eq!(parse_zip_compression(upload).unwrap(), ZipCompression::Zstd);
+        #[cfg(not(feature = "zstd"))]
+        assert!(
+            parse_zip_compression(upload)
+                .unwrap_err()
+                .to_string()
+                .contains("requires the s3-unspool-cli `zstd` feature")
+        );
     }
 
     #[test]

--- a/crates/s3-unspool-cli/src/main.rs
+++ b/crates/s3-unspool-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
+use std::result::Result;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -9,19 +10,7 @@ use std::time::{Duration, Instant};
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
-use s3_unspool::{
-    DryRunObjectReport, DryRunOperationStatus, LocalUnzipOptions, LocalUnzipReport,
-    LocalZipOptions, LocalZipReport, LocalZipSyncOptions, LocalZipToS3Report, ObjectReport,
-    OperationStatus, PutDiagnostics, S3Object, S3Prefix, S3PrefixLocalZipOptions,
-    S3PrefixUploadOptions, S3PrefixUploadReport, S3ZipLocalUnzipOptions, SyncDiagnostics,
-    SyncOptions, SyncReport, SyncSummary, UnzipDryRunReport, UnzipDryRunSummary, UploadOptions,
-    UploadProgress, UploadProgressHandler, UploadReport, ZipCompression, ZipDryRunReport,
-    dry_run_sync_zip_to_s3, dry_run_unzip_file_to_local, dry_run_unzip_file_to_s3,
-    dry_run_unzip_s3_zip_to_local, dry_run_upload_directory_zip_to_s3,
-    dry_run_zip_directory_to_file, dry_run_zip_s3_prefix_to_file, dry_run_zip_s3_prefix_to_s3,
-    sync_zip_to_s3, unzip_file_to_local, unzip_file_to_s3, unzip_s3_zip_to_local,
-    upload_directory_zip_to_s3, zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
-};
+use s3_unspool::*;
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
 

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -12,6 +12,10 @@ documentation = "https://docs.rs/s3-unspool"
 keywords = ["aws", "s3", "zip", "archive", "deployment"]
 categories = ["compression", "filesystem"]
 
+[features]
+default = ["zstd"]
+zstd = ["async-compression/zstd", "async_zip/zstd"]
+
 [dependencies]
 async-compression.workspace = true
 async_zip.workspace = true

--- a/crates/s3-unspool/README.md
+++ b/crates/s3-unspool/README.md
@@ -111,7 +111,8 @@ async fn main() -> s3_unspool::Result<()> {
 - Uploads missing files with `If-None-Match: *`.
 - Uploads changed files with `If-Match: <listed destination ETag>`.
 - Optionally deletes destination objects that are not present in the ZIP.
-- Supports Stored and Deflate ZIP entries.
+- Supports Stored, Deflate, and Zstandard method 93 ZIP entries when default
+  features are enabled.
 - Uploads generated source ZIPs with S3 multipart upload.
 - Uploads existing S3 prefixes into generated ZIPs without local object storage.
 - Preserves ZIP directory entries and zero-byte S3 folder marker objects.
@@ -169,6 +170,14 @@ download stalled-stream protection enabled for source reads.
 ZIPs created by `upload_directory_zip_to_s3` include an embedded catalog at
 `.s3-unspool/catalog.v1.json`. The catalog stores each file path and MD5 digest
 so later extracts can skip unchanged files before decompressing them.
+
+Generated ZIPs use Deflate for regular file entries by default. With default
+features enabled, set `UploadOptions::compression`,
+`LocalZipOptions::compression`, `S3PrefixUploadOptions::compression`, or
+`S3PrefixLocalZipOptions::compression` to `ZipCompression::Zstd` to write
+Zstandard method 93 entries. Use `default-features = false` to compile without
+Zstd support. Zstd-in-ZIP support is not universal in OS-native ZIP tools, so
+prefer Deflate when broad compatibility matters.
 
 Directory markers are preserved explicitly. ZIP directory entries such as
 `assets/empty/` extract to zero-byte S3 objects with trailing-slash keys, and

--- a/crates/s3-unspool/src/entry_reader.rs
+++ b/crates/s3-unspool/src/entry_reader.rs
@@ -2,6 +2,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_compression::tokio::bufread::DeflateDecoder;
+#[cfg(feature = "zstd")]
+use async_compression::tokio::bufread::ZstdDecoder;
 use async_zip::Compression;
 use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 
@@ -158,6 +160,8 @@ pub(crate) async fn entry_reader(
     match entry.compression {
         Compression::Stored => Ok(Box::pin(compressed)),
         Compression::Deflate => Ok(Box::pin(DeflateDecoder::new(BufReader::new(compressed)))),
+        #[cfg(feature = "zstd")]
+        Compression::Zstd => Ok(Box::pin(ZstdDecoder::new(BufReader::new(compressed)))),
         other => Err(Error::InvalidZipEntry {
             path: entry.zip_path.clone(),
             reason: format!("unsupported compression method {other:?}"),

--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -1352,6 +1352,8 @@ fn validate_local_stored_entry(
 
     match stored.compression() {
         Compression::Stored | Compression::Deflate => {}
+        #[cfg(feature = "zstd")]
+        Compression::Zstd => {}
         other => {
             return Err(Error::InvalidZipEntry {
                 path: zip_path.to_string(),

--- a/crates/s3-unspool/src/lib.rs
+++ b/crates/s3-unspool/src/lib.rs
@@ -147,8 +147,8 @@ pub use inspect::{S3ZipInfo, inspect_s3_zip};
 pub use options::{
     LocalUnzipOptions, LocalZipOptions, LocalZipSyncOptions, PutRetryPolicy, RetryJitter,
     S3PrefixLocalZipOptions, S3PrefixUploadOptions, S3ZipLocalUnzipOptions, SyncOptions,
-    UploadOptions, UploadProgress, UploadProgressHandler, adaptive_source_get_concurrency,
-    adaptive_source_window_capacity,
+    UploadOptions, UploadProgress, UploadProgressHandler, ZipCompression,
+    adaptive_source_get_concurrency, adaptive_source_window_capacity,
 };
 pub use report::{
     DryRunDiagnostics, DryRunObjectReport, DryRunOperationStatus, LocalUnzipDiagnostics,

--- a/crates/s3-unspool/src/options.rs
+++ b/crates/s3-unspool/src/options.rs
@@ -2,10 +2,41 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_zip::Compression;
 use serde::{Deserialize, Serialize};
 
 use crate::constants::*;
 use crate::s3_uri::{S3Object, S3Prefix};
+
+/// Compression method used for regular file entries when creating ZIP archives.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ZipCompression {
+    /// Use Deflate, the default ZIP compression method supported by common tools.
+    #[default]
+    Deflate,
+    /// Use Zstandard method 93 for regular file entries.
+    #[cfg(feature = "zstd")]
+    Zstd,
+}
+
+impl ZipCompression {
+    pub(crate) fn to_async_zip(self) -> Compression {
+        match self {
+            ZipCompression::Deflate => Compression::Deflate,
+            #[cfg(feature = "zstd")]
+            ZipCompression::Zstd => Compression::Zstd,
+        }
+    }
+
+    /// Returns a stable lowercase name for display or configuration.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ZipCompression::Deflate => "deflate",
+            #[cfg(feature = "zstd")]
+            ZipCompression::Zstd => "zstd",
+        }
+    }
+}
 
 /// Options for extracting a ZIP object from S3 into an S3 prefix.
 #[derive(Clone, Debug)]
@@ -209,6 +240,8 @@ pub struct UploadOptions {
     pub destination: S3Object,
     /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
     pub include_catalog: bool,
+    /// Compression method for regular file entries.
+    pub compression: ZipCompression,
     /// Buffer size used when streaming the ZIP body to S3.
     ///
     /// Must be greater than zero and no larger than 16 MiB.
@@ -230,6 +263,8 @@ pub struct LocalZipOptions {
     pub destination_zip: PathBuf,
     /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
     pub include_catalog: bool,
+    /// Compression method for regular file entries.
+    pub compression: ZipCompression,
     /// Optional progress callback invoked during upload preparation and ZIP streaming.
     pub progress: Option<UploadProgressHandler>,
 }
@@ -243,6 +278,8 @@ pub struct S3PrefixUploadOptions {
     pub destination: S3Object,
     /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
     pub include_catalog: bool,
+    /// Compression method for regular file entries.
+    pub compression: ZipCompression,
     /// Buffer size used when streaming the ZIP body to S3.
     ///
     /// Must be greater than zero and no larger than 16 MiB.
@@ -264,6 +301,8 @@ pub struct S3PrefixLocalZipOptions {
     pub destination_zip: PathBuf,
     /// Include the embedded update catalog at [`crate::EMBEDDED_CATALOG_PATH`].
     pub include_catalog: bool,
+    /// Compression method for regular file entries.
+    pub compression: ZipCompression,
     /// Optional progress callback invoked during source listing and ZIP streaming.
     pub progress: Option<UploadProgressHandler>,
 }
@@ -341,6 +380,7 @@ impl S3PrefixUploadOptions {
             source,
             destination,
             include_catalog: true,
+            compression: ZipCompression::Deflate,
             body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
             pipe_capacity: DEFAULT_PIPE_CAPACITY,
             progress: None,
@@ -355,6 +395,7 @@ impl LocalZipOptions {
             source_dir: source_dir.into(),
             destination_zip: destination_zip.into(),
             include_catalog: true,
+            compression: ZipCompression::Deflate,
             progress: None,
         }
     }
@@ -367,6 +408,7 @@ impl std::fmt::Debug for LocalZipOptions {
             .field("source_dir", &self.source_dir)
             .field("destination_zip", &self.destination_zip)
             .field("include_catalog", &self.include_catalog)
+            .field("compression", &self.compression)
             .field(
                 "progress",
                 &self.progress.as_ref().map(|_| "UploadProgressHandler"),
@@ -382,6 +424,7 @@ impl std::fmt::Debug for S3PrefixUploadOptions {
             .field("source", &self.source)
             .field("destination", &self.destination)
             .field("include_catalog", &self.include_catalog)
+            .field("compression", &self.compression)
             .field("body_chunk_size", &self.body_chunk_size)
             .field("pipe_capacity", &self.pipe_capacity)
             .field(
@@ -399,6 +442,7 @@ impl S3PrefixLocalZipOptions {
             source,
             destination_zip: destination_zip.into(),
             include_catalog: true,
+            compression: ZipCompression::Deflate,
             progress: None,
         }
     }
@@ -411,6 +455,7 @@ impl std::fmt::Debug for S3PrefixLocalZipOptions {
             .field("source", &self.source)
             .field("destination_zip", &self.destination_zip)
             .field("include_catalog", &self.include_catalog)
+            .field("compression", &self.compression)
             .field(
                 "progress",
                 &self.progress.as_ref().map(|_| "UploadProgressHandler"),
@@ -426,6 +471,7 @@ impl UploadOptions {
             source_dir: source_dir.into(),
             destination,
             include_catalog: true,
+            compression: ZipCompression::Deflate,
             body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
             pipe_capacity: DEFAULT_PIPE_CAPACITY,
             progress: None,
@@ -539,6 +585,7 @@ impl std::fmt::Debug for UploadOptions {
             .field("source_dir", &self.source_dir)
             .field("destination", &self.destination)
             .field("include_catalog", &self.include_catalog)
+            .field("compression", &self.compression)
             .field("body_chunk_size", &self.body_chunk_size)
             .field("pipe_capacity", &self.pipe_capacity)
             .field(

--- a/crates/s3-unspool/src/tests.rs
+++ b/crates/s3-unspool/src/tests.rs
@@ -36,9 +36,9 @@ use crate::zip_manifest::{
 use crate::{
     DryRunOperationStatus, Error, LocalUnzipOptions, LocalZipOptions, ObjectReport,
     OperationStatus, PutRetryPolicy, S3Object, S3Prefix, S3PrefixLocalZipOptions, SyncOptions,
-    SyncReport, SyncSummary, UploadProgress, UploadProgressHandler, dry_run_unzip_file_to_local,
-    dry_run_zip_directory_to_file, unzip_file_to_local, zip_directory_to_file,
-    zip_s3_prefix_to_file,
+    SyncReport, SyncSummary, UploadProgress, UploadProgressHandler, ZipCompression,
+    dry_run_unzip_file_to_local, dry_run_zip_directory_to_file, unzip_file_to_local,
+    zip_directory_to_file, zip_s3_prefix_to_file,
 };
 
 #[test]
@@ -280,9 +280,10 @@ async fn collects_and_writes_upload_zip_entries() {
     );
 
     let mut data = Vec::new();
-    let catalog_entries = write_upload_zip(&mut data, &entries, true, None)
-        .await
-        .unwrap();
+    let catalog_entries =
+        write_upload_zip(&mut data, &entries, true, ZipCompression::Deflate, None)
+            .await
+            .unwrap();
     assert_eq!(
         catalog_entries
             .iter()
@@ -333,6 +334,51 @@ async fn collects_and_writes_upload_zip_entries() {
     tokio::fs::remove_dir_all(root).await.unwrap();
 }
 
+#[cfg(feature = "zstd")]
+#[tokio::test]
+async fn upload_zip_can_write_zstd_file_entries() {
+    let root = unique_temp_dir("zip-upload-zstd");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    tokio::fs::write(root.join("a.txt"), b"alpha alpha alpha")
+        .await
+        .unwrap();
+
+    let entries = collect_upload_entries(&root).await.unwrap();
+    let mut data = Vec::new();
+    let catalog_entries = write_upload_zip(&mut data, &entries, true, ZipCompression::Zstd, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        catalog_entries
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.md5.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("a.txt", "ddb0513e8db13a8aa11fb685c75fd9a4")]
+    );
+
+    let zip = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let zip_entries = zip.file().entries().to_vec();
+    assert_eq!(zip_entries[0].compression(), Compression::Zstd);
+    assert_eq!(u16::from(zip_entries[0].compression()), 93);
+    assert_eq!(zip_entries[1].compression(), Compression::Deflate);
+    assert_eq!(
+        zip_entries[1].filename().as_str().unwrap(),
+        EMBEDDED_CATALOG_PATH
+    );
+
+    let mut file = zip.reader_with_entry(0).await.unwrap();
+    let mut file_bytes = Vec::new();
+    FuturesAsyncReadExt::read_to_end(&mut file, &mut file_bytes)
+        .await
+        .unwrap();
+    assert_eq!(file_bytes, b"alpha alpha alpha");
+
+    tokio::fs::remove_dir_all(root).await.unwrap();
+}
+
 #[tokio::test]
 async fn upload_zip_rejects_uncompressed_size_overflow() {
     let entries = vec![
@@ -349,7 +395,7 @@ async fn upload_zip_rejects_uncompressed_size_overflow() {
     ];
     let mut data = Vec::new();
 
-    let err = write_upload_zip(&mut data, &entries, false, None)
+    let err = write_upload_zip(&mut data, &entries, false, ZipCompression::Deflate, None)
         .await
         .unwrap_err();
 
@@ -375,9 +421,15 @@ async fn upload_zip_emits_file_progress_events() {
     });
 
     let mut data = Vec::new();
-    write_upload_zip(&mut data, &entries, true, Some(progress))
-        .await
-        .unwrap();
+    write_upload_zip(
+        &mut data,
+        &entries,
+        true,
+        ZipCompression::Deflate,
+        Some(progress),
+    )
+    .await
+    .unwrap();
 
     let events = events.lock().unwrap().clone();
     assert_eq!(
@@ -436,9 +488,15 @@ async fn upload_zip_progress_uses_measured_file_bytes() {
     });
 
     let mut data = Vec::new();
-    write_upload_zip(&mut data, &entries, false, Some(progress))
-        .await
-        .unwrap();
+    write_upload_zip(
+        &mut data,
+        &entries,
+        false,
+        ZipCompression::Deflate,
+        Some(progress),
+    )
+    .await
+    .unwrap();
 
     let events = events.lock().unwrap().clone();
     assert!(events.iter().any(|event| matches!(
@@ -619,6 +677,32 @@ async fn unzips_local_zip_to_local_directory_and_overwrites_files() {
     );
 
     tokio::fs::remove_dir_all(source_root).await.unwrap();
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[cfg(feature = "zstd")]
+#[tokio::test]
+async fn local_unzip_reads_zstd_entries() {
+    let zip_dir = unique_temp_dir("unzip-zstd-zip");
+    let destination = unique_temp_dir("unzip-zstd-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+
+    let zip_bytes = test_zip(&[("zstd.txt", Compression::Zstd, b"zstd payload".as_slice())]).await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let report = unzip_file_to_local(LocalUnzipOptions::new(&source_zip, &destination))
+        .await
+        .unwrap();
+
+    assert_eq!(report.summary.zip_files, 1);
+    assert_eq!(report.summary.uploaded_new, 1);
+    assert_eq!(
+        tokio::fs::read(destination.join("zstd.txt")).await.unwrap(),
+        b"zstd payload"
+    );
+
     tokio::fs::remove_dir_all(zip_dir).await.unwrap();
     tokio::fs::remove_dir_all(destination).await.unwrap();
 }
@@ -997,9 +1081,10 @@ async fn s3_prefix_upload_zip_writes_directory_markers() {
     }];
 
     let mut data = Vec::new();
-    let catalog_entries = write_upload_zip(&mut data, &entries, true, None)
-        .await
-        .unwrap();
+    let catalog_entries =
+        write_upload_zip(&mut data, &entries, true, ZipCompression::Deflate, None)
+            .await
+            .unwrap();
 
     assert!(catalog_entries.is_empty());
     let zip = async_zip::base::read::mem::ZipFileReader::new(data)
@@ -1774,6 +1859,30 @@ async fn entry_reader_streams_stored_and_deflated_entries_from_cached_ranges() {
         .await
         .unwrap();
     assert_eq!(deflated, b"bravo");
+}
+
+#[cfg(feature = "zstd")]
+#[tokio::test]
+async fn entry_reader_streams_zstd_entries_from_cached_ranges() {
+    let data = test_zip(&[("zstd.txt", Compression::Zstd, b"charlie".as_slice())]).await;
+    let source_len = data.len() as u64;
+    let reader = async_zip::base::read::mem::ZipFileReader::new(data.clone())
+        .await
+        .unwrap();
+    let destination = S3Prefix::parse("s3://bucket/prefix/").unwrap();
+    let manifest =
+        build_manifest_entries(reader.file().entries(), &destination, source_len).unwrap();
+    let store = block_store_from_zip(data, &manifest.entries);
+
+    assert_eq!(manifest.entries[0].compression, Compression::Zstd);
+    assert_eq!(u16::from(manifest.entries[0].compression), 93);
+
+    let mut zstd_reader = entry_reader(store, &manifest.entries[0]).await.unwrap();
+    let mut zstd = Vec::new();
+    TokioAsyncReadExt::read_to_end(&mut zstd_reader, &mut zstd)
+        .await
+        .unwrap();
+    assert_eq!(zstd, b"charlie");
 }
 
 #[tokio::test]

--- a/crates/s3-unspool/src/upload.rs
+++ b/crates/s3-unspool/src/upload.rs
@@ -24,7 +24,7 @@ use crate::error::{Error, Result, aws_error_message};
 use crate::extract::normalized_list_prefix;
 use crate::options::{
     LocalZipOptions, S3PrefixLocalZipOptions, S3PrefixUploadOptions, UploadOptions, UploadProgress,
-    UploadProgressHandler,
+    UploadProgressHandler, ZipCompression,
 };
 use crate::report::{LocalZipReport, S3PrefixUploadReport, UploadReport, ZipDryRunReport};
 use crate::s3_uri::{S3Object, S3Prefix};
@@ -105,20 +105,27 @@ pub async fn upload_directory_zip_to_s3(
     let upload_id = create_upload(client, &options.destination).await?;
     let (writer, reader) = tokio::io::duplex(options.pipe_capacity);
     let include_catalog = options.include_catalog;
+    let compression = options.compression;
     let progress = options.progress.clone();
     let finish_progress = progress.clone();
     let total_bytes = uncompressed_bytes;
     let producer = tokio::spawn(async move {
-        write_upload_zip(writer.compat_write(), &entries, include_catalog, progress)
-            .await
-            .inspect(|_| {
-                if let Some(progress) = &finish_progress {
-                    progress.emit(UploadProgress::Finished {
-                        total_files: total_entries,
-                        total_bytes,
-                    });
-                }
-            })
+        write_upload_zip(
+            writer.compat_write(),
+            &entries,
+            include_catalog,
+            compression,
+            progress,
+        )
+        .await
+        .inspect(|_| {
+            if let Some(progress) = &finish_progress {
+                progress.emit(UploadProgress::Finished {
+                    total_files: total_entries,
+                    total_bytes,
+                });
+            }
+        })
     });
 
     let upload_result = upload_parts(
@@ -211,6 +218,7 @@ pub async fn zip_directory_to_file(options: LocalZipOptions) -> Result<LocalZipR
         &options.destination_zip,
         &entries,
         options.include_catalog,
+        options.compression,
         options.progress.clone(),
         None,
     )
@@ -274,6 +282,7 @@ pub async fn zip_s3_prefix_to_s3(
     let upload_id = create_upload(client, &options.destination).await?;
     let (writer, reader) = tokio::io::duplex(options.pipe_capacity);
     let include_catalog = options.include_catalog;
+    let compression = options.compression;
     let progress = options.progress.clone();
     let finish_progress = progress.clone();
     let total_entries = entries.len();
@@ -284,6 +293,7 @@ pub async fn zip_s3_prefix_to_s3(
             writer.compat_write(),
             &entries,
             include_catalog,
+            compression,
             progress,
             &producer_client,
         )
@@ -396,6 +406,7 @@ pub async fn zip_s3_prefix_to_file(
         &options.destination_zip,
         &entries,
         options.include_catalog,
+        options.compression,
         options.progress.clone(),
         Some(client),
     )
@@ -473,6 +484,7 @@ async fn write_upload_zip_to_local_file(
     destination: &Path,
     entries: &[UploadEntry],
     include_catalog: bool,
+    compression: ZipCompression,
     progress: Option<UploadProgressHandler>,
     s3_client: Option<&Client>,
 ) -> Result<u64> {
@@ -488,6 +500,7 @@ async fn write_upload_zip_to_local_file(
         file.compat_write(),
         entries,
         include_catalog,
+        compression,
         progress,
         s3_client,
     )
@@ -1205,31 +1218,50 @@ pub(crate) async fn write_upload_zip<W>(
     writer: W,
     entries: &[UploadEntry],
     include_catalog: bool,
+    compression: ZipCompression,
     progress: Option<UploadProgressHandler>,
 ) -> Result<Vec<EmbeddedCatalogEntry>>
 where
     W: AsyncWrite + Unpin,
 {
-    write_upload_zip_entries(writer, entries, include_catalog, progress, None).await
+    write_upload_zip_entries(
+        writer,
+        entries,
+        include_catalog,
+        compression,
+        progress,
+        None,
+    )
+    .await
 }
 
 async fn write_upload_zip_with_s3_client<W>(
     writer: W,
     entries: &[UploadEntry],
     include_catalog: bool,
+    compression: ZipCompression,
     progress: Option<UploadProgressHandler>,
     client: &Client,
 ) -> Result<Vec<EmbeddedCatalogEntry>>
 where
     W: AsyncWrite + Unpin,
 {
-    write_upload_zip_entries(writer, entries, include_catalog, progress, Some(client)).await
+    write_upload_zip_entries(
+        writer,
+        entries,
+        include_catalog,
+        compression,
+        progress,
+        Some(client),
+    )
+    .await
 }
 
 async fn write_upload_zip_entries<W>(
     writer: W,
     entries: &[UploadEntry],
     include_catalog: bool,
+    compression: ZipCompression,
     progress: Option<UploadProgressHandler>,
     s3_client: Option<&Client>,
 ) -> Result<Vec<EmbeddedCatalogEntry>>
@@ -1259,6 +1291,7 @@ where
             &mut zip_writer,
             entry,
             include_catalog,
+            compression,
             &progress,
             UploadProgressContext {
                 current_file,
@@ -1320,6 +1353,7 @@ async fn write_zip_entry<W>(
     zip_writer: &mut ZipFileWriter<W>,
     entry: &UploadEntry,
     hash_entry: bool,
+    compression: ZipCompression,
     progress: &Option<UploadProgressHandler>,
     progress_context: UploadProgressContext,
     s3_client: Option<&Client>,
@@ -1333,7 +1367,7 @@ where
         return Ok((0, None));
     }
 
-    let builder = ZipEntryBuilder::new(entry.zip_path.clone().into(), Compression::Deflate);
+    let builder = ZipEntryBuilder::new(entry.zip_path.clone().into(), compression.to_async_zip());
     let mut entry_writer = zip_writer.write_entry_stream(builder).await?;
     let mut state = UploadEntryWriteState {
         hasher: hash_entry.then(Md5::new),

--- a/crates/s3-unspool/src/zip_manifest.rs
+++ b/crates/s3-unspool/src/zip_manifest.rs
@@ -259,6 +259,8 @@ fn validate_stored_entry(
 
     match stored.compression() {
         Compression::Stored | Compression::Deflate => {}
+        #[cfg(feature = "zstd")]
+        Compression::Zstd => {}
         other => {
             return Err(Error::InvalidZipEntry {
                 path: zip_path.to_string(),

--- a/lambda/s3-unspool-lambda/Cargo.toml
+++ b/lambda/s3-unspool-lambda/Cargo.toml
@@ -17,7 +17,7 @@ aws-config.workspace = true
 aws-sdk-s3.workspace = true
 lambda_runtime.workspace = true
 libc.workspace = true
-s3-unspool.workspace = true
+s3-unspool = { workspace = true, features = ["zstd"] }
 serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
## Summary
- add a default-enabled zstd feature and ZipCompression option for ZIP creation
- support reading ZIP entries compressed with Zstandard method 93
- expose CLI `zip --compression deflate|zstd` and document opt-out behavior

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p s3-unspool`
- `cargo +1.95.0 test -p s3-unspool-cli`
- `cargo +1.95.0 test -p s3-unspool --no-default-features`
- `cargo +1.95.0 test -p s3-unspool-cli --no-default-features`
- `cargo +1.95.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.95.0 clippy -p s3-unspool --all-targets --no-default-features -- -D warnings`
- `cargo +1.95.0 clippy -p s3-unspool-cli --all-targets --no-default-features -- -D warnings`
- `git diff --check origin/main`

Closes #3