### PR TITLE
unzip: add gitignore-style selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +830,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -1178,6 +1213,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1537,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2025,6 +2089,7 @@ dependencies = [
  "hex",
  "http-body 1.0.1",
  "http-body-util",
+ "ignore",
  "libc",
  "md-5",
  "serde",
@@ -2065,6 +2130,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2674,6 +2748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,6 +2824,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ fastrand = "2.4.1"
 hex = "0.4.3"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
+ignore = "0.4.25"
 lambda_runtime = "1.1.3"
 libc = "0.2.186"
 md5 = { package = "md-5", version = "0.11.0" }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,45 @@ async fn main() -> s3_unspool::Result<()> {
 to benchmark or force the fallback extract-and-hash comparison path against the
 same ZIP object.
 
+### Extract Selected ZIP Entries
+
+Set `SyncOptions::selection` when only a subset of entries should be restored
+from an S3 ZIP. Selection patterns use gitignore-style syntax and are applied
+before source range planning, so the existing block coalescing still reduces
+ranged `GetObject` calls for the selected entries. Exclude-only selections
+restore every non-excluded ZIP entry.
+
+```rust
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::Client;
+use s3_unspool::{S3Object, S3Prefix, SyncOptions, UnzipSelection, sync_zip_to_s3};
+
+#[tokio::main]
+async fn main() -> s3_unspool::Result<()> {
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let client = Client::new(&config);
+
+    let extract = SyncOptions::new(
+        S3Object::parse("s3://my-bucket/releases/site.zip")?,
+        S3Prefix::parse("s3://my-bucket/www/")?,
+    )
+    .with_selection(
+        UnzipSelection::new()
+            .include("index.md")
+            .include("docs/**/*.md")
+            .exclude("docs/drafts/**"),
+    );
+
+    let report = sync_zip_to_s3(&client, extract).await?;
+    println!("processed entries: {}", report.summary.zip_files);
+
+    Ok(())
+}
+```
+
+Selected extracts cannot be combined with `delete_extra`, because unselected
+destination objects are outside the restore scope.
+
 ### Upload a Directory as a Cataloged ZIP
 
 Use `upload_directory_zip_to_s3` when you want `s3-unspool` to create the source
@@ -408,6 +447,11 @@ Useful unzip options:
   created, replaced, skipped, or deleted without writing or deleting anything.
 - `--delete-extra`: delete destination objects under the prefix that are not in
   the ZIP.
+- `--include PATTERN`: extract ZIP entries matching this gitignore-style
+  pattern. Repeat to include multiple patterns.
+- `--exclude PATTERN`: exclude ZIP entries matching this gitignore-style
+  pattern. Repeat to exclude multiple patterns. Selection cannot be combined
+  with `--delete-extra`.
 - `--concurrency <N>`: maximum number of ZIP entries processed at once. The CLI
   default is `64`.
 - `--report`: add a formatted operation report to the CLI transcript.
@@ -572,7 +616,9 @@ Payload fields:
   "deleteExtra": false,
   "diagnostics": false,
   "ignoreCatalog": false,
-  "includeOperations": false
+  "includeOperations": false,
+  "includePatterns": [],
+  "excludePatterns": []
 }
 ```
 
@@ -588,6 +634,11 @@ the configured memory size: `4` workers at `128` MB, `6` at `256` MB, `8` at
 Set `"ignoreCatalog": true` to force extraction to ignore the embedded MD5
 catalog and measure the fallback extract-and-hash path. The payload also accepts
 `"ignoreEmbeddedCatalog": true`.
+
+Set `"includePatterns"` or `"excludePatterns"` to restore only selected ZIP
+entries from the archive. Selected Lambda extracts use the same source-range
+planning as full extracts, and they reject `"deleteExtra": true` for the same
+reason as the CLI: unselected destination objects are outside the restore scope.
 
 Lambda responses omit per-object `operations` by default so large benchmark
 invokes stay below the synchronous invoke response limit. Set

--- a/crates/s3-unspool-cli/src/main.rs
+++ b/crates/s3-unspool-cli/src/main.rs
@@ -14,13 +14,13 @@ use s3_unspool::{
     LocalZipOptions, LocalZipReport, LocalZipSyncOptions, LocalZipToS3Report, ObjectReport,
     OperationStatus, PutDiagnostics, S3Object, S3Prefix, S3PrefixLocalZipOptions,
     S3PrefixUploadOptions, S3PrefixUploadReport, S3ZipLocalUnzipOptions, SyncDiagnostics,
-    SyncOptions, SyncReport, SyncSummary, UnzipDryRunReport, UnzipDryRunSummary, UploadOptions,
-    UploadProgress, UploadProgressHandler, UploadReport, ZipDryRunReport, dry_run_sync_zip_to_s3,
-    dry_run_unzip_file_to_local, dry_run_unzip_file_to_s3, dry_run_unzip_s3_zip_to_local,
-    dry_run_upload_directory_zip_to_s3, dry_run_zip_directory_to_file,
-    dry_run_zip_s3_prefix_to_file, dry_run_zip_s3_prefix_to_s3, sync_zip_to_s3,
-    unzip_file_to_local, unzip_file_to_s3, unzip_s3_zip_to_local, upload_directory_zip_to_s3,
-    zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
+    SyncOptions, SyncReport, SyncSummary, UnzipDryRunReport, UnzipDryRunSummary, UnzipSelection,
+    UploadOptions, UploadProgress, UploadProgressHandler, UploadReport, ZipDryRunReport,
+    dry_run_sync_zip_to_s3, dry_run_unzip_file_to_local, dry_run_unzip_file_to_s3,
+    dry_run_unzip_s3_zip_to_local, dry_run_upload_directory_zip_to_s3,
+    dry_run_zip_directory_to_file, dry_run_zip_s3_prefix_to_file, dry_run_zip_s3_prefix_to_s3,
+    sync_zip_to_s3, unzip_file_to_local, unzip_file_to_s3, unzip_s3_zip_to_local,
+    upload_directory_zip_to_s3, zip_directory_to_file, zip_s3_prefix_to_file, zip_s3_prefix_to_s3,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
@@ -82,23 +82,33 @@ async fn run_unzip(
     let diagnostics = matches.get_flag("diagnostics");
     let ignore_catalog = matches.get_flag("ignore-catalog");
     let dry_run = matches.get_flag("dry-run");
+    let selection = unzip_selection_from_matches(matches);
     let report_destination = ReportDestination::from_cli_value(matches.get_one::<String>("report"));
     let source = parse_zip_source(source)?;
     let destination = parse_tree_destination(destination)?;
     validate_delete_extra_destination(delete_extra, &destination)?;
+    validate_delete_extra_selection(delete_extra, &selection)?;
     validate_diagnostics_source(diagnostics, &source)?;
+
+    let mut details = vec![
+        format!("{} -> {}", source.display(), destination.display()),
+        format!(
+            "{} workers{}{}",
+            concurrency,
+            if delete_extra { ", delete extra" } else { "" },
+            if dry_run { ", no changes" } else { "" }
+        ),
+    ];
+    if !selection.is_empty() {
+        details.push(format!(
+            "{} selection pattern filters",
+            selection.as_patterns().len()
+        ));
+    }
 
     output.write(&Transcript::running(
         if dry_run { "Unzip dry run" } else { "Unzip" },
-        vec![
-            format!("{} -> {}", source.display(), destination.display()),
-            format!(
-                "{} workers{}{}",
-                concurrency,
-                if delete_extra { ", delete extra" } else { "" },
-                if dry_run { ", no changes" } else { "" }
-            ),
-        ],
+        details,
     ))?;
 
     let activity = output.start_activity(
@@ -118,6 +128,7 @@ async fn run_unzip(
             options.collect_diagnostics = diagnostics;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
+            options.selection = selection;
             if dry_run {
                 UnzipCommandReport::DryRun(dry_run_sync_zip_to_s3(&client, options).await?)
             } else {
@@ -131,6 +142,7 @@ async fn run_unzip(
             options.delete_extra = delete_extra;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
+            options.selection = selection;
             if dry_run {
                 UnzipCommandReport::DryRun(dry_run_unzip_file_to_s3(&client, options).await?)
             } else {
@@ -144,6 +156,7 @@ async fn run_unzip(
             options.collect_diagnostics = diagnostics;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
+            options.selection = selection;
             if dry_run {
                 UnzipCommandReport::DryRun(dry_run_unzip_s3_zip_to_local(&client, options).await?)
             } else {
@@ -155,6 +168,7 @@ async fn run_unzip(
             options.concurrency = concurrency;
             options.collect_operations = !matches!(report_destination, ReportDestination::None);
             options.ignore_embedded_catalog = ignore_catalog;
+            options.selection = selection;
             if dry_run {
                 UnzipCommandReport::DryRun(dry_run_unzip_file_to_local(options).await?)
             } else {
@@ -410,6 +424,32 @@ fn validate_delete_extra_destination(
     }
 }
 
+fn unzip_selection_from_matches(matches: &ArgMatches) -> UnzipSelection {
+    let mut selection = UnzipSelection::new();
+    if let Some(includes) = matches.get_many::<String>("include") {
+        for include in includes {
+            selection = selection.include(include.clone());
+        }
+    }
+    if let Some(excludes) = matches.get_many::<String>("exclude") {
+        for exclude in excludes {
+            selection = selection.exclude(exclude.clone());
+        }
+    }
+    selection
+}
+
+fn validate_delete_extra_selection(
+    delete_extra: bool,
+    selection: &UnzipSelection,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if delete_extra && !selection.is_empty() {
+        Err("--delete-extra cannot be combined with --include or --exclude".into())
+    } else {
+        Ok(())
+    }
+}
+
 fn validate_diagnostics_source(
     diagnostics: bool,
     source: &ZipSource,
@@ -477,6 +517,20 @@ fn cli() -> Command {
                         .long("dry-run")
                         .help("Inspect the ZIP and destination, then report planned changes without writing or deleting anything")
                         .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("include")
+                        .long("include")
+                        .value_name("PATTERN")
+                        .help("Extract ZIP entries matching this gitignore-style pattern; repeat to include multiple patterns")
+                        .action(ArgAction::Append),
+                )
+                .arg(
+                    Arg::new("exclude")
+                        .long("exclude")
+                        .value_name("PATTERN")
+                        .help("Exclude ZIP entries matching this gitignore-style pattern; repeat to exclude multiple patterns")
+                        .action(ArgAction::Append),
                 )
                 .arg(
                     Arg::new("concurrency")
@@ -1759,6 +1813,10 @@ mod tests {
                 "unzip",
                 "--delete-extra",
                 "--ignore-catalog",
+                "--include",
+                "docs/**/*.md",
+                "--exclude",
+                "docs/drafts/**",
                 "s3://source-bucket/archive.zip",
                 "s3://destination-bucket/prefix/",
             ])
@@ -1775,6 +1833,18 @@ mod tests {
         };
         assert!(extract.get_flag("delete-extra"));
         assert!(extract.get_flag("ignore-catalog"));
+        assert_eq!(
+            extract
+                .get_many::<String>("include")
+                .map(|values| values.map(String::as_str).collect::<Vec<_>>()),
+            Some(vec!["docs/**/*.md"])
+        );
+        assert_eq!(
+            extract
+                .get_many::<String>("exclude")
+                .map(|values| values.map(String::as_str).collect::<Vec<_>>()),
+            Some(vec!["docs/drafts/**"])
+        );
         assert_eq!(
             extract.get_one::<String>("source").map(String::as_str),
             Some("s3://source-bucket/archive.zip")
@@ -1893,6 +1963,15 @@ mod tests {
                 Some(destination)
             );
         }
+    }
+
+    #[test]
+    fn rejects_delete_extra_with_unzip_selection() {
+        let selection = UnzipSelection::new().include("index.md");
+
+        let err = validate_delete_extra_selection(true, &selection).unwrap_err();
+
+        assert!(err.to_string().contains("--delete-extra"));
     }
 
     #[test]

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -25,6 +25,7 @@ futures-util.workspace = true
 hex.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
+ignore.workspace = true
 libc.workspace = true
 md5.workspace = true
 serde.workspace = true

--- a/crates/s3-unspool/README.md
+++ b/crates/s3-unspool/README.md
@@ -110,6 +110,8 @@ async fn main() -> s3_unspool::Result<()> {
 - Uses listed destination ETags instead of per-object `HeadObject` calls.
 - Uploads missing files with `If-None-Match: *`.
 - Uploads changed files with `If-Match: <listed destination ETag>`.
+- Can selectively extract gitignore-style ZIP path patterns with
+  `UnzipSelection`; selection is applied before source range planning.
 - Optionally deletes destination objects that are not present in the ZIP.
 - Supports Stored and Deflate ZIP entries.
 - Uploads generated source ZIPs with S3 multipart upload.

--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -26,6 +26,8 @@ use futures_util::TryStreamExt;
 use futures_util::stream::{self, StreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;
+use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use md5::{Digest, Md5};
 use tokio::io::AsyncRead;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
@@ -53,7 +55,7 @@ use crate::entry_reader::{EntryReader, entry_reader};
 use crate::error::{Error, Result, aws_error_context, aws_error_message};
 use crate::options::{
     LocalUnzipOptions, LocalZipSyncOptions, PutRetryPolicy, RetryJitter, S3ZipLocalUnzipOptions,
-    SyncOptions, adaptive_source_window_capacity,
+    SyncOptions, UnzipSelection, adaptive_source_window_capacity,
 };
 use crate::range::{
     BlockStore, SourceClient, SourceDiagnosticsCollector, plan_source_blocks,
@@ -71,7 +73,8 @@ use crate::upload::{
     invalid_local_path, is_platform_path_alias_symlink, replace_temp_file, temp_sibling_path,
 };
 use crate::zip_manifest::{
-    ManifestEntry, load_zip_manifest, normalize_zip_entry_path, validate_crc32_value,
+    ManifestEntry, ZipEntryPath, load_zip_manifest, load_zip_manifest_with_filter,
+    normalize_zip_entry_path, validate_crc32_value,
 };
 
 const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(30);
@@ -335,6 +338,84 @@ async fn stop_progress_logger(progress_task: Option<JoinHandle<()>>) {
     }
 }
 
+#[derive(Debug, Default)]
+struct NormalizedUnzipSelection {
+    matcher: Option<Gitignore>,
+    pattern_count: usize,
+    default_include: bool,
+}
+
+impl NormalizedUnzipSelection {
+    fn is_empty(&self) -> bool {
+        self.matcher.is_none()
+    }
+
+    fn matches(&self, entry: &ZipEntryPath) -> bool {
+        let Some(matcher) = &self.matcher else {
+            return true;
+        };
+
+        let path = if entry.is_directory {
+            entry.path.trim_end_matches('/')
+        } else {
+            entry.path.as_str()
+        };
+        match matcher.matched_path_or_any_parents(path, entry.is_directory) {
+            Match::Ignore(_) => true,
+            Match::Whitelist(_) => false,
+            Match::None => self.default_include,
+        }
+    }
+}
+
+fn normalize_unzip_selection(selection: &UnzipSelection) -> Result<NormalizedUnzipSelection> {
+    if selection.is_empty() {
+        return Ok(NormalizedUnzipSelection::default());
+    }
+
+    let mut builder = GitignoreBuilder::new("");
+    let mut pattern_count = 0;
+    let mut has_include_pattern = false;
+    for raw_pattern in selection.as_patterns() {
+        builder.add_line(None, raw_pattern).map_err(|err| {
+            Error::InvalidOption(format!(
+                "invalid unzip selection pattern {raw_pattern:?}: {err}"
+            ))
+        })?;
+        let trimmed = raw_pattern.trim_start();
+        if !trimmed.trim_end().is_empty() && !trimmed.starts_with('#') {
+            pattern_count += 1;
+            if !trimmed.starts_with('!') {
+                has_include_pattern = true;
+            }
+        }
+    }
+    if pattern_count == 0 {
+        return Ok(NormalizedUnzipSelection::default());
+    }
+    let matcher = builder
+        .build()
+        .map_err(|err| Error::InvalidOption(format!("invalid unzip selection: {err}")))?;
+
+    Ok(NormalizedUnzipSelection {
+        matcher: Some(matcher),
+        pattern_count,
+        default_include: !has_include_pattern,
+    })
+}
+
+fn validate_delete_extra_selection(
+    delete_extra: bool,
+    selection: &NormalizedUnzipSelection,
+) -> Result<()> {
+    if delete_extra && !selection.is_empty() {
+        return Err(Error::InvalidOption(
+            "delete_extra cannot be combined with unzip selection because it would delete destination objects outside the selected ZIP entries".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Extracts missing or changed files from an S3 ZIP object into an S3 prefix.
 ///
 /// The source ZIP is read with ranged `GetObject` requests. Destination objects
@@ -359,6 +440,8 @@ pub async fn sync_zip_to_s3_with_clients(
     mut options: SyncOptions,
 ) -> Result<SyncReport> {
     validate_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
+    validate_delete_extra_selection(options.delete_extra, &selection)?;
     let started = Instant::now();
     tracing::info!(
         source_bucket = %options.source.bucket,
@@ -412,24 +495,37 @@ pub async fn sync_zip_to_s3_with_clients(
         diagnostics: diagnostics.clone(),
     });
 
-    let manifest = load_zip_manifest(
-        Arc::clone(&source),
-        &options.destination,
-        options.ignore_embedded_catalog,
-        options.source_block_size,
-        Some(crate::constants::S3_SINGLE_PUT_LIMIT),
-    )
-    .await?;
-    resolve_source_window_capacity(&mut options, source_head.len, manifest.entries.len());
+    let manifest = if selection.is_empty() {
+        load_zip_manifest(
+            Arc::clone(&source),
+            &options.destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            Some(crate::constants::S3_SINGLE_PUT_LIMIT),
+        )
+        .await?
+    } else {
+        load_zip_manifest_with_filter(
+            Arc::clone(&source),
+            &options.destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            Some(crate::constants::S3_SINGLE_PUT_LIMIT),
+            |entry| selection.matches(entry),
+        )
+        .await?
+    };
+    let entries = manifest.entries;
+    resolve_source_window_capacity(&mut options, source_head.len, entries.len());
     validate_source_range_options(&options, source_head.len)?;
-    let entries_with_catalog_md5 = manifest
-        .entries
+    let entries_with_catalog_md5 = entries
         .iter()
         .filter(|entry| entry.catalog_md5.is_some())
         .count();
     tracing::info!(
-        zip_files = manifest.entries.len(),
+        zip_files = entries.len(),
         entries_with_catalog_md5,
+        selection_patterns = selection.pattern_count,
         source_window_capacity = options.source_window_capacity,
         elapsed_ms = started.elapsed().as_millis() as u64,
         "zip manifest loaded"
@@ -442,7 +538,6 @@ pub async fn sync_zip_to_s3_with_clients(
         elapsed_ms = started.elapsed().as_millis() as u64,
         "destination prefix listed"
     );
-    let entries = manifest.entries;
     let total_entries = entries.len();
     let expected_keys = options.delete_extra.then(|| {
         entries
@@ -666,6 +761,8 @@ pub async fn unzip_file_to_s3(
     options: LocalZipSyncOptions,
 ) -> Result<LocalZipToS3Report> {
     validate_local_zip_sync_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
+    validate_delete_extra_selection(options.delete_extra, &selection)?;
     let reader = open_local_zip_reader(&options.source_zip).await?;
     let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
     let mut entries = local_zip_entries_for_s3(
@@ -673,6 +770,7 @@ pub async fn unzip_file_to_s3(
         &options.destination,
         source_len,
         true,
+        |entry| selection.matches(entry),
     )?;
     if !options.ignore_embedded_catalog {
         let catalog = load_local_embedded_catalog(&reader, entries.catalog_index).await;
@@ -738,9 +836,11 @@ pub async fn unzip_file_to_s3(
 /// local directories, and extra local files are left untouched.
 pub async fn unzip_s3_zip_to_local(
     client: &Client,
-    mut options: S3ZipLocalUnzipOptions,
+    options: S3ZipLocalUnzipOptions,
 ) -> Result<LocalUnzipReport> {
+    let mut options = options;
     validate_s3_zip_local_unzip_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
     let destination_root = prepare_local_destination_root(&options.destination_dir).await?;
     let started = Instant::now();
     let source_head = head_source(client, &options.source).await?;
@@ -759,14 +859,26 @@ pub async fn unzip_s3_zip_to_local(
         bucket: "__local__".to_string(),
         prefix: String::new(),
     };
-    let manifest = load_zip_manifest(
-        Arc::clone(&source),
-        &local_destination,
-        options.ignore_embedded_catalog,
-        options.source_block_size,
-        None,
-    )
-    .await?;
+    let manifest = if selection.is_empty() {
+        load_zip_manifest(
+            Arc::clone(&source),
+            &local_destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            None,
+        )
+        .await?
+    } else {
+        load_zip_manifest_with_filter(
+            Arc::clone(&source),
+            &local_destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            None,
+            |entry| selection.matches(entry),
+        )
+        .await?
+    };
     resolve_s3_zip_local_window_capacity(&mut options, source_head.len, manifest.entries.len());
     validate_s3_zip_local_source_range_options(&options, source_head.len)?;
 
@@ -845,10 +957,15 @@ pub async fn unzip_s3_zip_to_local(
 /// local directories, and extra local files are left untouched.
 pub async fn unzip_file_to_local(options: LocalUnzipOptions) -> Result<LocalUnzipReport> {
     validate_local_unzip_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
     let destination_root = prepare_local_destination_root(&options.destination_dir).await?;
     let reader = open_local_zip_reader(&options.source_zip).await?;
     let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
-    let entries = local_zip_entries_for_local(reader.file().entries(), source_len, false)?.entries;
+    let entries =
+        local_zip_entries_for_local(reader.file().entries(), source_len, false, |entry| {
+            selection.matches(entry)
+        })?
+        .entries;
     validate_local_destination_zip_paths(entries.iter().map(|entry| entry.zip_path.as_str()))?;
     let destination_case_insensitive =
         destination_uses_case_insensitive_paths(&destination_root).await?;
@@ -903,6 +1020,8 @@ pub async fn dry_run_sync_zip_to_s3_with_clients(
     mut options: SyncOptions,
 ) -> Result<UnzipDryRunReport> {
     validate_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
+    validate_delete_extra_selection(options.delete_extra, &selection)?;
     let source_head = head_source(source_client, &options.source).await?;
     let diagnostics = options
         .collect_diagnostics
@@ -916,14 +1035,26 @@ pub async fn dry_run_sync_zip_to_s3_with_clients(
         diagnostics: diagnostics.clone(),
     });
 
-    let manifest = load_zip_manifest(
-        Arc::clone(&source),
-        &options.destination,
-        options.ignore_embedded_catalog,
-        options.source_block_size,
-        Some(crate::constants::S3_SINGLE_PUT_LIMIT),
-    )
-    .await?;
+    let manifest = if selection.is_empty() {
+        load_zip_manifest(
+            Arc::clone(&source),
+            &options.destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            Some(crate::constants::S3_SINGLE_PUT_LIMIT),
+        )
+        .await?
+    } else {
+        load_zip_manifest_with_filter(
+            Arc::clone(&source),
+            &options.destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            Some(crate::constants::S3_SINGLE_PUT_LIMIT),
+            |entry| selection.matches(entry),
+        )
+        .await?
+    };
     resolve_source_window_capacity(&mut options, source_head.len, manifest.entries.len());
     validate_source_range_options(&options, source_head.len)?;
 
@@ -1022,6 +1153,8 @@ pub async fn dry_run_unzip_file_to_s3(
     options: LocalZipSyncOptions,
 ) -> Result<UnzipDryRunReport> {
     validate_local_zip_sync_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
+    validate_delete_extra_selection(options.delete_extra, &selection)?;
     let reader = open_local_zip_reader(&options.source_zip).await?;
     let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
     let mut entries = local_zip_entries_for_s3(
@@ -1029,6 +1162,7 @@ pub async fn dry_run_unzip_file_to_s3(
         &options.destination,
         source_len,
         true,
+        |entry| selection.matches(entry),
     )?;
     if !options.ignore_embedded_catalog {
         let catalog = load_local_embedded_catalog(&reader, entries.catalog_index).await;
@@ -1095,6 +1229,7 @@ pub async fn dry_run_unzip_s3_zip_to_local(
     mut options: S3ZipLocalUnzipOptions,
 ) -> Result<UnzipDryRunReport> {
     validate_s3_zip_local_unzip_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
     let destination_root =
         validate_local_destination_root_for_dry_run(&options.destination_dir).await?;
     let source_head = head_source(client, &options.source).await?;
@@ -1113,14 +1248,26 @@ pub async fn dry_run_unzip_s3_zip_to_local(
         bucket: "__local__".to_string(),
         prefix: String::new(),
     };
-    let manifest = load_zip_manifest(
-        Arc::clone(&source),
-        &local_destination,
-        options.ignore_embedded_catalog,
-        options.source_block_size,
-        None,
-    )
-    .await?;
+    let manifest = if selection.is_empty() {
+        load_zip_manifest(
+            Arc::clone(&source),
+            &local_destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            None,
+        )
+        .await?
+    } else {
+        load_zip_manifest_with_filter(
+            Arc::clone(&source),
+            &local_destination,
+            options.ignore_embedded_catalog,
+            options.source_block_size,
+            None,
+            |entry| selection.matches(entry),
+        )
+        .await?
+    };
     resolve_s3_zip_local_window_capacity(&mut options, source_head.len, manifest.entries.len());
     validate_s3_zip_local_source_range_options(&options, source_head.len)?;
 
@@ -1168,11 +1315,16 @@ pub async fn dry_run_unzip_s3_zip_to_local(
 /// Plans extracting a local ZIP file into a local directory without writing files.
 pub async fn dry_run_unzip_file_to_local(options: LocalUnzipOptions) -> Result<UnzipDryRunReport> {
     validate_local_unzip_options(&options)?;
+    let selection = normalize_unzip_selection(&options.selection)?;
     let destination_root =
         validate_local_destination_root_for_dry_run(&options.destination_dir).await?;
     let reader = open_local_zip_reader(&options.source_zip).await?;
     let source_len = tokio::fs::metadata(&options.source_zip).await?.len();
-    let entries = local_zip_entries_for_local(reader.file().entries(), source_len, false)?.entries;
+    let entries =
+        local_zip_entries_for_local(reader.file().entries(), source_len, false, |entry| {
+            selection.matches(entry)
+        })?
+        .entries;
     validate_local_destination_zip_paths(entries.iter().map(|entry| entry.zip_path.as_str()))?;
     let destination_case_insensitive =
         destination_uses_case_insensitive_paths_for_dry_run(&options.destination_dir).await?;
@@ -1239,18 +1391,30 @@ fn local_zip_entries_for_s3(
     destination: &S3Prefix,
     source_len: u64,
     enforce_s3_limit: bool,
+    include_entry: impl Fn(&ZipEntryPath) -> bool,
 ) -> Result<LocalZipEntries> {
-    local_zip_entries(stored_entries, source_len, enforce_s3_limit, |zip_path| {
-        destination.join_key(zip_path)
-    })
+    local_zip_entries(
+        stored_entries,
+        source_len,
+        enforce_s3_limit,
+        |zip_path| destination.join_key(zip_path),
+        include_entry,
+    )
 }
 
 fn local_zip_entries_for_local(
     stored_entries: &[StoredZipEntry],
     source_len: u64,
     enforce_s3_limit: bool,
+    include_entry: impl Fn(&ZipEntryPath) -> bool,
 ) -> Result<LocalZipEntries> {
-    local_zip_entries(stored_entries, source_len, enforce_s3_limit, str::to_string)
+    local_zip_entries(
+        stored_entries,
+        source_len,
+        enforce_s3_limit,
+        str::to_string,
+        include_entry,
+    )
 }
 
 fn local_zip_entries(
@@ -1258,6 +1422,7 @@ fn local_zip_entries(
     source_len: u64,
     enforce_s3_limit: bool,
     destination: impl Fn(&str) -> String,
+    include_entry: impl Fn(&ZipEntryPath) -> bool,
 ) -> Result<LocalZipEntries> {
     let mut seen = HashSet::new();
     let mut entries = Vec::new();
@@ -1272,13 +1437,20 @@ fn local_zip_entries(
                 reason: err.to_string(),
             })?;
         let zip_entry_path = normalize_zip_entry_path(raw_path)?;
-        let zip_path = zip_entry_path.path;
-        let is_directory = zip_entry_path.is_directory;
 
-        if !is_directory && zip_path == EMBEDDED_CATALOG_PATH {
+        if !zip_entry_path.is_directory && zip_entry_path.path == EMBEDDED_CATALOG_PATH {
             catalog_index = Some(index);
             continue;
         }
+
+        if !include_entry(&zip_entry_path) {
+            continue;
+        }
+
+        let ZipEntryPath {
+            path: zip_path,
+            is_directory,
+        } = zip_entry_path;
 
         validate_local_stored_entry(
             stored,
@@ -5225,12 +5397,16 @@ mod tests {
             .unwrap();
         let destination = S3Prefix::parse("s3://destination-bucket/prefix/").unwrap();
 
-        let err =
-            match local_zip_entries_for_s3(reader.file().entries(), &destination, source_len, true)
-            {
-                Ok(_) => panic!("directory entry with nonzero CRC should be rejected"),
-                Err(err) => err,
-            };
+        let err = match local_zip_entries_for_s3(
+            reader.file().entries(),
+            &destination,
+            source_len,
+            true,
+            |_| true,
+        ) {
+            Ok(_) => panic!("directory entry with nonzero CRC should be rejected"),
+            Err(err) => err,
+        };
 
         assert!(matches!(
             err,

--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -382,10 +382,14 @@ fn normalize_unzip_selection(selection: &UnzipSelection) -> Result<NormalizedUnz
                 "invalid unzip selection pattern {raw_pattern:?}: {err}"
             ))
         })?;
-        let trimmed = raw_pattern.trim_start();
-        if !trimmed.trim_end().is_empty() && !trimmed.starts_with('#') {
+        let line = if raw_pattern.ends_with("\\ ") {
+            raw_pattern.as_str()
+        } else {
+            raw_pattern.trim_end()
+        };
+        if !line.is_empty() && !line.starts_with('#') {
             pattern_count += 1;
-            if !trimmed.starts_with('!') {
+            if !line.starts_with('!') {
                 has_include_pattern = true;
             }
         }

--- a/crates/s3-unspool/src/lib.rs
+++ b/crates/s3-unspool/src/lib.rs
@@ -43,6 +43,15 @@
 //! them. Set [`SyncOptions::ignore_embedded_catalog`] when you need to measure
 //! or force the fallback extract-and-hash path.
 //!
+//! Set [`SyncOptions::selection`] or the equivalent local unzip option field
+//! when only a subset of ZIP paths should be restored. Selection patterns use
+//! gitignore-style syntax and are applied before source range planning, so
+//! ranged `GetObject` requests are planned only for selected entries that still
+//! need source bytes. Exclude-only selections restore every non-excluded ZIP
+//! path. Selected extracts reject
+//! [`SyncOptions::delete_extra`] because unselected destination objects are
+//! outside the restore scope.
+//!
 //! ZIP directory entries round-trip as zero-byte S3 marker objects whose keys
 //! end in `/`. Local upload preserves empty directories as ZIP directory
 //! entries, and S3-prefix upload preserves zero-byte S3 marker objects as ZIP
@@ -68,6 +77,34 @@
 //!
 //! let report = sync_zip_to_s3(&client, extract).await?;
 //! println!("uploaded changed files: {}", report.summary.uploaded_changed);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Extract Selected Entries from an S3 ZIP
+//!
+//! ```no_run
+//! use aws_config::BehaviorVersion;
+//! use aws_sdk_s3::Client;
+//! use s3_unspool::{S3Object, S3Prefix, SyncOptions, UnzipSelection, sync_zip_to_s3};
+//!
+//! # async fn run() -> s3_unspool::Result<()> {
+//! let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+//! let client = Client::new(&config);
+//!
+//! let extract = SyncOptions::new(
+//!     S3Object::parse("s3://my-bucket/releases/site.zip")?,
+//!     S3Prefix::parse("s3://my-bucket/www/")?,
+//! )
+//! .with_selection(
+//!     UnzipSelection::new()
+//!         .include("index.md")
+//!         .include("docs/**/*.md")
+//!         .exclude("docs/drafts/**"),
+//! );
+//!
+//! let report = sync_zip_to_s3(&client, extract).await?;
+//! println!("processed entries: {}", report.summary.zip_files);
 //! # Ok(())
 //! # }
 //! ```
@@ -147,8 +184,8 @@ pub use inspect::{S3ZipInfo, inspect_s3_zip};
 pub use options::{
     LocalUnzipOptions, LocalZipOptions, LocalZipSyncOptions, PutRetryPolicy, RetryJitter,
     S3PrefixLocalZipOptions, S3PrefixUploadOptions, S3ZipLocalUnzipOptions, SyncOptions,
-    UploadOptions, UploadProgress, UploadProgressHandler, adaptive_source_get_concurrency,
-    adaptive_source_window_capacity,
+    UnzipSelection, UploadOptions, UploadProgress, UploadProgressHandler,
+    adaptive_source_get_concurrency, adaptive_source_window_capacity,
 };
 pub use report::{
     DryRunDiagnostics, DryRunObjectReport, DryRunOperationStatus, LocalUnzipDiagnostics,

--- a/crates/s3-unspool/src/options.rs
+++ b/crates/s3-unspool/src/options.rs
@@ -7,6 +7,90 @@ use serde::{Deserialize, Serialize};
 use crate::constants::*;
 use crate::s3_uri::{S3Object, S3Prefix};
 
+/// ZIP entry selection patterns for unzip APIs.
+///
+/// When no patterns are configured, unzip operations process every supported ZIP
+/// entry. Patterns are matched against normalized ZIP paths, not local
+/// filesystem paths or destination S3 keys. Use
+/// [`UnzipSelection::new`]/[`UnzipSelection::include`] for builder-style
+/// configuration, or pass an array such as `["docs/**", "!docs/drafts/**"]`
+/// to `with_selection`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct UnzipSelection {
+    patterns: Vec<String>,
+}
+
+impl UnzipSelection {
+    /// Creates an empty selection that extracts every supported ZIP entry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a selection from ordered include/exclude patterns.
+    ///
+    /// Patterns use gitignore-style matching. Later patterns override earlier
+    /// patterns, and patterns prefixed with `!` exclude matching ZIP paths.
+    /// If only exclude patterns are configured, every non-excluded ZIP path is
+    /// selected.
+    pub fn patterns(patterns: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            patterns: patterns.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Adds an include pattern.
+    ///
+    /// Leading `!` and `#` characters are treated as literal path characters
+    /// in the builder API. Use [`Self::patterns`] for raw gitignore lines.
+    pub fn include(mut self, pattern: impl Into<String>) -> Self {
+        self.patterns
+            .push(escape_leading_gitignore_marker(pattern.into()));
+        self
+    }
+
+    /// Adds an exclude pattern.
+    ///
+    /// Leading `!` and `#` characters are treated as literal path characters
+    /// in the builder API. Use [`Self::patterns`] for raw gitignore lines.
+    pub fn exclude(mut self, pattern: impl Into<String>) -> Self {
+        self.patterns.push(format!(
+            "!{}",
+            escape_leading_gitignore_marker(pattern.into())
+        ));
+        self
+    }
+
+    /// Returns true when no selection patterns have been configured.
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Returns the ordered selection patterns.
+    pub fn as_patterns(&self) -> &[String] {
+        &self.patterns
+    }
+}
+
+impl<const N: usize> From<[&str; N]> for UnzipSelection {
+    fn from(patterns: [&str; N]) -> Self {
+        Self::patterns(patterns)
+    }
+}
+
+impl From<Vec<String>> for UnzipSelection {
+    fn from(patterns: Vec<String>) -> Self {
+        Self { patterns }
+    }
+}
+
+fn escape_leading_gitignore_marker(pattern: String) -> String {
+    if pattern.starts_with('!') || pattern.starts_with('#') {
+        format!("\\{pattern}")
+    } else {
+        pattern
+    }
+}
+
 /// Options for extracting a ZIP object from S3 into an S3 prefix.
 #[derive(Clone, Debug)]
 pub struct SyncOptions {
@@ -19,6 +103,10 @@ pub struct SyncOptions {
     /// This option requires a non-empty destination prefix so a bucket root is
     /// never swept accidentally.
     pub delete_extra: bool,
+    /// ZIP entry selection. Empty selection extracts every supported entry.
+    ///
+    /// Selection cannot be combined with [`Self::delete_extra`].
+    pub selection: UnzipSelection,
     /// Collect source scheduler diagnostics in the returned report.
     pub collect_diagnostics: bool,
     /// Ignore the embedded update catalog even when the ZIP contains one.
@@ -80,6 +168,7 @@ impl SyncOptions {
             source,
             destination,
             delete_extra: false,
+            selection: UnzipSelection::default(),
             collect_diagnostics: false,
             ignore_embedded_catalog: false,
             fail_on_conditional_conflict: false,
@@ -95,6 +184,12 @@ impl SyncOptions {
             body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
             pipe_capacity: DEFAULT_PIPE_CAPACITY,
         }
+    }
+
+    /// Sets ZIP entry selection patterns.
+    pub fn with_selection(mut self, selection: impl Into<UnzipSelection>) -> Self {
+        self.selection = selection.into();
+        self
     }
 }
 
@@ -280,6 +375,10 @@ pub struct LocalZipSyncOptions {
     /// This option requires a non-empty destination prefix so a bucket root is
     /// never treated as a sync deletion scope.
     pub delete_extra: bool,
+    /// ZIP entry selection. Empty selection extracts every supported entry.
+    ///
+    /// Selection cannot be combined with [`Self::delete_extra`].
+    pub selection: UnzipSelection,
     /// Ignore the embedded update catalog even when the ZIP contains one.
     pub ignore_embedded_catalog: bool,
     /// Collect one operation record per processed object in the returned report.
@@ -299,6 +398,8 @@ pub struct S3ZipLocalUnzipOptions {
     pub source: S3Object,
     /// Destination local directory.
     pub destination_dir: PathBuf,
+    /// ZIP entry selection. Empty selection extracts every supported entry.
+    pub selection: UnzipSelection,
     /// Collect source scheduler diagnostics in the returned report.
     pub collect_diagnostics: bool,
     /// Ignore the embedded update catalog even when the ZIP contains one.
@@ -326,6 +427,8 @@ pub struct LocalUnzipOptions {
     pub source_zip: PathBuf,
     /// Destination local directory.
     pub destination_dir: PathBuf,
+    /// ZIP entry selection. Empty selection extracts every supported entry.
+    pub selection: UnzipSelection,
     /// Ignore the embedded update catalog even when the ZIP contains one.
     pub ignore_embedded_catalog: bool,
     /// Collect one operation record per processed entry in the returned report.
@@ -440,12 +543,19 @@ impl LocalZipSyncOptions {
             source_zip: source_zip.into(),
             destination,
             delete_extra: false,
+            selection: UnzipSelection::default(),
             ignore_embedded_catalog: false,
             collect_operations: true,
             concurrency: DEFAULT_CONCURRENCY,
             body_chunk_size: DEFAULT_BODY_CHUNK_SIZE,
             pipe_capacity: DEFAULT_PIPE_CAPACITY,
         }
+    }
+
+    /// Sets ZIP entry selection patterns.
+    pub fn with_selection(mut self, selection: impl Into<UnzipSelection>) -> Self {
+        self.selection = selection.into();
+        self
     }
 }
 
@@ -456,6 +566,7 @@ impl std::fmt::Debug for LocalZipSyncOptions {
             .field("source_zip", &self.source_zip)
             .field("destination", &self.destination)
             .field("delete_extra", &self.delete_extra)
+            .field("selection", &self.selection)
             .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
             .field("collect_operations", &self.collect_operations)
             .field("concurrency", &self.concurrency)
@@ -471,6 +582,7 @@ impl S3ZipLocalUnzipOptions {
         Self {
             source,
             destination_dir: destination_dir.into(),
+            selection: UnzipSelection::default(),
             collect_diagnostics: false,
             ignore_embedded_catalog: false,
             collect_operations: true,
@@ -482,6 +594,12 @@ impl S3ZipLocalUnzipOptions {
             source_window_memory_budget_mb: None,
         }
     }
+
+    /// Sets ZIP entry selection patterns.
+    pub fn with_selection(mut self, selection: impl Into<UnzipSelection>) -> Self {
+        self.selection = selection.into();
+        self
+    }
 }
 
 impl std::fmt::Debug for S3ZipLocalUnzipOptions {
@@ -490,6 +608,7 @@ impl std::fmt::Debug for S3ZipLocalUnzipOptions {
             .debug_struct("S3ZipLocalUnzipOptions")
             .field("source", &self.source)
             .field("destination_dir", &self.destination_dir)
+            .field("selection", &self.selection)
             .field("collect_diagnostics", &self.collect_diagnostics)
             .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
             .field("collect_operations", &self.collect_operations)
@@ -512,10 +631,17 @@ impl LocalUnzipOptions {
         Self {
             source_zip: source_zip.into(),
             destination_dir: destination_dir.into(),
+            selection: UnzipSelection::default(),
             ignore_embedded_catalog: false,
             collect_operations: true,
             concurrency: DEFAULT_CONCURRENCY,
         }
+    }
+
+    /// Sets ZIP entry selection patterns.
+    pub fn with_selection(mut self, selection: impl Into<UnzipSelection>) -> Self {
+        self.selection = selection.into();
+        self
     }
 }
 
@@ -525,6 +651,7 @@ impl std::fmt::Debug for LocalUnzipOptions {
             .debug_struct("LocalUnzipOptions")
             .field("source_zip", &self.source_zip)
             .field("destination_dir", &self.destination_dir)
+            .field("selection", &self.selection)
             .field("ignore_embedded_catalog", &self.ignore_embedded_catalog)
             .field("collect_operations", &self.collect_operations)
             .field("concurrency", &self.concurrency)

--- a/crates/s3-unspool/src/options.rs
+++ b/crates/s3-unspool/src/options.rs
@@ -41,7 +41,7 @@ impl UnzipSelection {
     /// Adds an include pattern.
     ///
     /// Leading `!` and `#` characters are treated as literal path characters
-    /// in the builder API. Use [`Self::patterns`] for raw gitignore lines.
+    /// in the builder API. Use [`Self::patterns`] for raw selection lines.
     pub fn include(mut self, pattern: impl Into<String>) -> Self {
         self.patterns
             .push(escape_leading_gitignore_marker(pattern.into()));
@@ -51,7 +51,7 @@ impl UnzipSelection {
     /// Adds an exclude pattern.
     ///
     /// Leading `!` and `#` characters are treated as literal path characters
-    /// in the builder API. Use [`Self::patterns`] for raw gitignore lines.
+    /// in the builder API. Use [`Self::patterns`] for raw selection lines.
     pub fn exclude(mut self, pattern: impl Into<String>) -> Self {
         self.patterns.push(format!(
             "!{}",

--- a/crates/s3-unspool/src/tests.rs
+++ b/crates/s3-unspool/src/tests.rs
@@ -924,6 +924,52 @@ async fn local_unzip_extracts_with_include_then_exclude_selection() {
 }
 
 #[tokio::test]
+async fn local_unzip_selection_preserves_leading_space_patterns() {
+    let zip_dir = unique_temp_dir("unzip-selected-leading-space-zip");
+    let destination = unique_temp_dir("unzip-selected-leading-space-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        (" #notes.md", Compression::Stored, b"notes".as_slice()),
+        (
+            " !important.md",
+            Compression::Stored,
+            b"important".as_slice(),
+        ),
+        ("other.md", Compression::Stored, b"other".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let options = LocalUnzipOptions::new(&source_zip, &destination)
+        .with_selection([" #notes.md", " !important.md"]);
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.zip_files, 2);
+    assert_eq!(report.summary.uploaded_new, 2);
+    assert_eq!(
+        tokio::fs::read(destination.join(" #notes.md"))
+            .await
+            .unwrap(),
+        b"notes"
+    );
+    assert_eq!(
+        tokio::fs::read(destination.join(" !important.md"))
+            .await
+            .unwrap(),
+        b"important"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("other.md"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
 async fn local_unzip_creates_shared_missing_parent_concurrently() {
     let zip_dir = unique_temp_dir("unzip-shared-parent-zip");
     let destination = unique_temp_dir("unzip-shared-parent-destination");

--- a/crates/s3-unspool/src/tests.rs
+++ b/crates/s3-unspool/src/tests.rs
@@ -30,15 +30,15 @@ use crate::upload::{
 };
 use crate::zip_manifest::{
     ManifestBuild, ManifestEntry, apply_embedded_catalog, build_manifest_entries,
-    build_manifest_entries_with_size_limit, count_zip_file_entries, normalize_zip_entry_path,
-    normalize_zip_file_path,
+    build_manifest_entries_with_size_limit, build_manifest_entries_with_size_limit_and_filter,
+    count_zip_file_entries, normalize_zip_entry_path, normalize_zip_file_path,
 };
 use crate::{
     DryRunOperationStatus, Error, LocalUnzipOptions, LocalZipOptions, ObjectReport,
     OperationStatus, PutRetryPolicy, S3Object, S3Prefix, S3PrefixLocalZipOptions, SyncOptions,
-    SyncReport, SyncSummary, UploadProgress, UploadProgressHandler, dry_run_unzip_file_to_local,
-    dry_run_zip_directory_to_file, unzip_file_to_local, zip_directory_to_file,
-    zip_s3_prefix_to_file,
+    SyncReport, SyncSummary, UnzipSelection, UploadProgress, UploadProgressHandler,
+    dry_run_unzip_file_to_local, dry_run_zip_directory_to_file, unzip_file_to_local,
+    zip_directory_to_file, zip_s3_prefix_to_file,
 };
 
 #[test]
@@ -66,6 +66,25 @@ fn rejects_source_without_key() {
 fn rejects_s3_object_uri_with_only_repeated_slashes() {
     let err = S3Object::parse("s3://bucket//").unwrap_err();
     assert!(err.to_string().contains("missing object key"));
+}
+
+#[test]
+fn unzip_selection_builder_treats_leading_markers_as_literals() {
+    let selection = UnzipSelection::new()
+        .include("!important.md")
+        .include("#notes.md")
+        .exclude("!draft.md")
+        .exclude("#draft.md");
+
+    assert_eq!(
+        selection.as_patterns(),
+        [
+            "\\!important.md",
+            "\\#notes.md",
+            "!\\!draft.md",
+            "!\\#draft.md"
+        ]
+    );
 }
 
 #[test]
@@ -713,6 +732,193 @@ async fn dry_run_local_unzip_reports_directory_component_error_path() {
             .contains("exists and is not a directory")
     );
 
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_extracts_selected_exact_path_only() {
+    let zip_dir = unique_temp_dir("unzip-selected-exact-zip");
+    let destination = unique_temp_dir("unzip-selected-exact-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("a.txt", Compression::Stored, b"alpha".as_slice()),
+        ("nested/b.txt", Compression::Stored, b"bravo".as_slice()),
+        ("nested/c.txt", Compression::Stored, b"charlie".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let options =
+        LocalUnzipOptions::new(&source_zip, &destination).with_selection(["nested/b.txt"]);
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.zip_files, 1);
+    assert_eq!(report.summary.uploaded_new, 1);
+    assert_eq!(
+        tokio::fs::read(destination.join("nested").join("b.txt"))
+            .await
+            .unwrap(),
+        b"bravo"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("a.txt"))
+            .await
+            .is_err()
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("nested").join("c.txt"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_extracts_selected_prefix_only() {
+    let zip_dir = unique_temp_dir("unzip-selected-prefix-zip");
+    let destination = unique_temp_dir("unzip-selected-prefix-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("a.txt", Compression::Stored, b"alpha".as_slice()),
+        ("nested/", Compression::Stored, b"".as_slice()),
+        ("nested/b.txt", Compression::Stored, b"bravo".as_slice()),
+        ("nested/c.txt", Compression::Stored, b"charlie".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let options = LocalUnzipOptions::new(&source_zip, &destination).with_selection(["nested/"]);
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.zip_files, 3);
+    assert_eq!(report.summary.uploaded_new, 3);
+    assert!(
+        tokio::fs::metadata(destination.join("nested"))
+            .await
+            .unwrap()
+            .is_dir()
+    );
+    assert_eq!(
+        tokio::fs::read(destination.join("nested").join("b.txt"))
+            .await
+            .unwrap(),
+        b"bravo"
+    );
+    assert_eq!(
+        tokio::fs::read(destination.join("nested").join("c.txt"))
+            .await
+            .unwrap(),
+        b"charlie"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("a.txt"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_extracts_with_exclude_only_selection() {
+    let zip_dir = unique_temp_dir("unzip-selected-exclude-only-zip");
+    let destination = unique_temp_dir("unzip-selected-exclude-only-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("index.md", Compression::Stored, b"index".as_slice()),
+        ("docs/live.md", Compression::Stored, b"live".as_slice()),
+        (
+            "docs/drafts/old.md",
+            Compression::Stored,
+            b"draft".as_slice(),
+        ),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let options = LocalUnzipOptions::new(&source_zip, &destination)
+        .with_selection(UnzipSelection::new().exclude("docs/drafts/**"));
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.zip_files, 2);
+    assert_eq!(report.summary.uploaded_new, 2);
+    assert_eq!(
+        tokio::fs::read(destination.join("index.md")).await.unwrap(),
+        b"index"
+    );
+    assert_eq!(
+        tokio::fs::read(destination.join("docs").join("live.md"))
+            .await
+            .unwrap(),
+        b"live"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("docs").join("drafts").join("old.md"))
+            .await
+            .is_err()
+    );
+    tokio::fs::remove_dir_all(zip_dir).await.unwrap();
+    tokio::fs::remove_dir_all(destination).await.unwrap();
+}
+
+#[tokio::test]
+async fn local_unzip_extracts_with_include_then_exclude_selection() {
+    let zip_dir = unique_temp_dir("unzip-selected-include-exclude-zip");
+    let destination = unique_temp_dir("unzip-selected-include-exclude-destination");
+    let source_zip = zip_dir.join("site.zip");
+    tokio::fs::create_dir_all(&zip_dir).await.unwrap();
+    tokio::fs::create_dir_all(&destination).await.unwrap();
+    let zip_bytes = test_zip(&[
+        ("index.md", Compression::Stored, b"index".as_slice()),
+        ("docs/live.md", Compression::Stored, b"live".as_slice()),
+        (
+            "docs/drafts/old.md",
+            Compression::Stored,
+            b"draft".as_slice(),
+        ),
+        ("images/logo.png", Compression::Stored, b"image".as_slice()),
+    ])
+    .await;
+    tokio::fs::write(&source_zip, zip_bytes).await.unwrap();
+
+    let options = LocalUnzipOptions::new(&source_zip, &destination).with_selection(
+        UnzipSelection::new()
+            .include("docs/**")
+            .exclude("docs/drafts/**"),
+    );
+    let report = unzip_file_to_local(options).await.unwrap();
+
+    assert_eq!(report.summary.zip_files, 1);
+    assert_eq!(report.summary.uploaded_new, 1);
+    assert_eq!(
+        tokio::fs::read(destination.join("docs").join("live.md"))
+            .await
+            .unwrap(),
+        b"live"
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("index.md"))
+            .await
+            .is_err()
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("docs").join("drafts").join("old.md"))
+            .await
+            .is_err()
+    );
+    assert!(
+        tokio::fs::metadata(destination.join("images").join("logo.png"))
+            .await
+            .is_err()
+    );
     tokio::fs::remove_dir_all(zip_dir).await.unwrap();
     tokio::fs::remove_dir_all(destination).await.unwrap();
 }
@@ -1677,6 +1883,32 @@ async fn manifest_size_limit_can_be_disabled_for_local_unzip() {
     assert_eq!(manifest.entries.len(), 1);
     assert_eq!(manifest.entries[0].zip_path, "large.txt");
     assert_eq!(manifest.entries[0].size, 5);
+}
+
+#[tokio::test]
+async fn manifest_selection_skips_unselected_size_limit_failures() {
+    let data = test_zip(&[
+        ("selected.txt", Compression::Stored, b"ok".as_slice()),
+        ("large.txt", Compression::Stored, b"alpha".as_slice()),
+    ])
+    .await;
+    let source_len = data.len() as u64;
+    let reader = async_zip::base::read::mem::ZipFileReader::new(data)
+        .await
+        .unwrap();
+    let destination = S3Prefix::parse("s3://bucket/prefix/").unwrap();
+
+    let manifest = build_manifest_entries_with_size_limit_and_filter(
+        reader.file().entries(),
+        &destination,
+        source_len,
+        Some(4),
+        |entry| entry.path == "selected.txt",
+    )
+    .unwrap();
+
+    assert_eq!(manifest.entries.len(), 1);
+    assert_eq!(manifest.entries[0].zip_path, "selected.txt");
 }
 
 #[tokio::test]

--- a/crates/s3-unspool/src/zip_manifest.rs
+++ b/crates/s3-unspool/src/zip_manifest.rs
@@ -55,14 +55,34 @@ pub(crate) async fn load_zip_manifest(
     source_block_size: usize,
     entry_size_limit: Option<u64>,
 ) -> Result<ZipManifest> {
+    load_zip_manifest_with_filter(
+        source,
+        destination,
+        ignore_embedded_catalog,
+        source_block_size,
+        entry_size_limit,
+        |_| true,
+    )
+    .await
+}
+
+pub(crate) async fn load_zip_manifest_with_filter(
+    source: Arc<SourceClient>,
+    destination: &S3Prefix,
+    ignore_embedded_catalog: bool,
+    source_block_size: usize,
+    entry_size_limit: Option<u64>,
+    include_entry: impl Fn(&ZipEntryPath) -> bool,
+) -> Result<ZipManifest> {
     let reader = S3RangeReader::new(Arc::clone(&source), source_block_size);
     let reader = ZipFileReader::with_tokio(reader).await?;
     let zip_file = reader.file().clone();
-    let build = build_manifest_entries_with_size_limit(
+    let build = build_manifest_entries_with_size_limit_and_filter(
         zip_file.entries(),
         destination,
         source.len,
         entry_size_limit,
+        include_entry,
     )?;
     let catalog = if ignore_embedded_catalog {
         HashMap::new()
@@ -93,11 +113,28 @@ pub(crate) fn build_manifest_entries(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn build_manifest_entries_with_size_limit(
     entries: &[StoredZipEntry],
     destination: &S3Prefix,
     source_len: u64,
     entry_size_limit: Option<u64>,
+) -> Result<ManifestBuild> {
+    build_manifest_entries_with_size_limit_and_filter(
+        entries,
+        destination,
+        source_len,
+        entry_size_limit,
+        |_| true,
+    )
+}
+
+pub(crate) fn build_manifest_entries_with_size_limit_and_filter(
+    entries: &[StoredZipEntry],
+    destination: &S3Prefix,
+    source_len: u64,
+    entry_size_limit: Option<u64>,
+    include_entry: impl Fn(&ZipEntryPath) -> bool,
 ) -> Result<ManifestBuild> {
     let mut seen = HashSet::new();
     let mut manifest = Vec::new();
@@ -110,13 +147,20 @@ pub(crate) fn build_manifest_entries_with_size_limit(
 
     for (index, stored) in entries.iter().enumerate() {
         let zip_entry_path = stored_zip_entry_path(stored)?;
-        let zip_path = zip_entry_path.path;
-        let is_directory = zip_entry_path.is_directory;
 
-        if !is_directory && zip_path == EMBEDDED_CATALOG_PATH {
+        if !zip_entry_path.is_directory && zip_entry_path.path == EMBEDDED_CATALOG_PATH {
             catalog_index = Some(index);
             continue;
         }
+
+        if !include_entry(&zip_entry_path) {
+            continue;
+        }
+
+        let ZipEntryPath {
+            path: zip_path,
+            is_directory,
+        } = zip_entry_path;
 
         validate_stored_entry(stored, &zip_path, is_directory, entry_size_limit)?;
         if !seen.insert(zip_path.clone()) {

--- a/events/invoke.json
+++ b/events/invoke.json
@@ -5,5 +5,7 @@
   "diagnostics": false,
   "ignoreCatalog": false,
   "includeOperations": false,
+  "includePatterns": [],
+  "excludePatterns": [],
   "concurrency": 16
 }

--- a/lambda/s3-unspool-lambda/src/main.rs
+++ b/lambda/s3-unspool-lambda/src/main.rs
@@ -4,7 +4,7 @@ use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use lambda_runtime::{Error as LambdaError, LambdaEvent, service_fn};
 use s3_unspool::{
     ObjectReport, S3Object, S3Prefix, SyncDiagnostics, SyncOptions, SyncReport, SyncSummary,
-    adaptive_source_get_concurrency, sync_zip_to_s3_with_clients,
+    UnzipSelection, adaptive_source_get_concurrency, sync_zip_to_s3_with_clients,
 };
 use serde::{Deserialize, Serialize};
 
@@ -28,6 +28,10 @@ struct InvokePayload {
     ignore_embedded_catalog: bool,
     #[serde(default, alias = "includeOperations")]
     include_operations: bool,
+    #[serde(default, alias = "include", alias = "includePatterns")]
+    include_patterns: Vec<String>,
+    #[serde(default, alias = "exclude", alias = "excludePatterns")]
+    exclude_patterns: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -72,6 +76,8 @@ async fn handle(event: LambdaEvent<InvokePayload>) -> Result<InvokeResponse, Lam
         diagnostics = payload.diagnostics,
         include_operations,
         ignore_embedded_catalog = payload.ignore_embedded_catalog,
+        selection_includes = payload.include_patterns.len(),
+        selection_excludes = payload.exclude_patterns.len(),
         concurrency,
         "lambda extract invoke started"
     );
@@ -166,6 +172,14 @@ impl InvokePayload {
         options.concurrency = concurrency;
         options.ignore_embedded_catalog = self.ignore_embedded_catalog;
         options.collect_operations = self.include_operations;
+        let mut selection = UnzipSelection::new();
+        for pattern in self.include_patterns {
+            selection = selection.include(pattern);
+        }
+        for pattern in self.exclude_patterns {
+            selection = selection.exclude(pattern);
+        }
+        options.selection = selection;
         Ok(options)
     }
 }
@@ -206,6 +220,8 @@ mod tests {
         assert_eq!(payload.concurrency, None);
         assert!(!payload.ignore_embedded_catalog);
         assert!(!payload.include_operations);
+        assert!(payload.include_patterns.is_empty());
+        assert!(payload.exclude_patterns.is_empty());
     }
 
     #[test]
@@ -218,7 +234,9 @@ mod tests {
                 "collectDiagnostics": true,
                 "concurrency": 8,
                 "ignoreCatalog": true,
-                "includeOperations": true
+                "includeOperations": true,
+                "includePatterns": ["docs/**/*.md", "index.md"],
+                "excludePatterns": ["docs/drafts/**"]
             }"#,
         )
         .unwrap();
@@ -240,6 +258,10 @@ mod tests {
         assert!(!options.fail_on_conditional_conflict);
         assert!(options.collect_operations);
         assert_eq!(options.source_window_memory_budget_mb, None);
+        assert_eq!(
+            options.selection.as_patterns(),
+            ["docs/**/*.md", "index.md", "!docs/drafts/**"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `UnzipSelection` with gitignore-style include/exclude patterns and both builder and array-style configuration
- apply selection before manifest and source-range planning across normal and dry-run unzip paths
- expose selection through CLI `--include`/`--exclude`, Lambda `includePatterns`/`excludePatterns`, docs, and tests

## Issue
No matching GitHub issue was found for selective extraction. The only open issue is #3 for Zstandard ZIP support, so this PR intentionally does not include a closing keyword for that unrelated issue.

## Validation
- `cargo test -p s3-unspool`
- `cargo test -p s3-unspool-cli`
- `cargo test -p s3-unspool-lambda`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p s3-unspool --no-deps`
- `git diff --check origin/main...HEAD`
