### PR TITLE
release: harden publish bootstrap for beta.4

### DIFF
--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -12,6 +12,7 @@ on:
       - "crates/s3-unspool-cli/**"
       - "dist-workspace.toml"
       - "rust-toolchain.toml"
+      - "scripts/check-crates-io-publish-target.sh"
   workflow_dispatch:
 
 permissions: {}
@@ -112,6 +113,12 @@ jobs:
             echo "tag-flag=${tag_flag}"
             echo "publishing=${publishing}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Validate crates.io publish target
+        if: ${{ steps.release.outputs.publishing == 'true' }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: scripts/check-crates-io-publish-target.sh s3-unspool s3-unspool-cli
 
       - name: Install dist
         shell: bash
@@ -448,36 +455,10 @@ jobs:
             echo "tag=v${version}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Reject existing crate versions
-        shell: bash
+      - name: Recheck crates.io publish target
         env:
           VERSION: ${{ steps.crate.outputs.version }}
-        run: |
-          set -euo pipefail
-          check_absent() {
-            crate="$1"
-            status="$(curl -L -sS \
-              --connect-timeout 10 \
-              --max-time 30 \
-              --retry 3 \
-              --retry-delay 2 \
-              --retry-all-errors \
-              -o response.json \
-              -w "%{http_code}" \
-              -H "User-Agent: alessandrobologna/s3-unspool release workflow" \
-              "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
-            if [ "$status" = "200" ]; then
-              echo "crate ${crate} ${VERSION} is already published" >&2
-              exit 1
-            fi
-            if [ "$status" != "404" ]; then
-              cat response.json >&2
-              echo "unexpected crates.io response ${status} for ${crate} ${VERSION}" >&2
-              exit 1
-            fi
-          }
-          check_absent s3-unspool
-          check_absent s3-unspool-cli
+        run: scripts/check-crates-io-publish-target.sh s3-unspool s3-unspool-cli
 
       - name: Dry-run library publish
         run: cargo publish -p s3-unspool --dry-run

--- a/.github/workflows/s3-unspool-ci.yml
+++ b/.github/workflows/s3-unspool-ci.yml
@@ -13,6 +13,7 @@ on:
       - "crates/s3-unspool-cli/**"
       - "dist-workspace.toml"
       - "rust-toolchain.toml"
+      - "scripts/check-crates-io-publish-target.sh"
 
 permissions: {}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3-unspool"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "s3-unspool-cli"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ignore = "0.4.25"
 lambda_runtime = "1.1.3"
 libc = "0.2.186"
 md5 = { package = "md-5", version = "0.11.0" }
-s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.3", default-features = false }
+s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.4", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 terminal_size = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Install the CLI with `cargo-binstall` when prebuilt GitHub Release artifacts are
 available:
 
 ```sh
-cargo binstall s3-unspool-cli --version 0.1.0-beta.3
+cargo binstall s3-unspool-cli --version 0.1.0-beta.4
 ```
 
 The CLI crate name is `s3-unspool-cli`, but the installed command is
@@ -399,7 +399,7 @@ The CLI runs the same zip and unzip flows from a terminal. Install the
 pre-release binary with `cargo-binstall`, or build it from a checkout:
 
 ```sh
-cargo binstall s3-unspool-cli --version 0.1.0-beta.3
+cargo binstall s3-unspool-cli --version 0.1.0-beta.4
 ```
 
 ```sh
@@ -590,7 +590,7 @@ identifiers such as `0.1.0-alpha.1`, `0.1.0-beta.1`, or `0.1.0-rc.1`.
 Consumers opt into a pre-release explicitly:
 
 ```sh
-cargo add s3-unspool@0.1.0-beta.3
+cargo add s3-unspool@0.1.0-beta.4
 ```
 
 Releases are published by the manual `Publish s3-unspool` GitHub Actions
@@ -600,6 +600,13 @@ crate first, waits for registry propagation, publishes the CLI crate, and only
 then creates the matching `v<version>` GitHub Release. Configure both crates on
 crates.io to trust this repository's `publish-s3-unspool.yml` workflow and the
 `release` GitHub environment before running it.
+
+Trusted Publishing can publish new versions of an existing crate, but it cannot
+create a crate name for the first time. Bootstrap each published crate once with
+a manual `cargo publish` using an owner API token, then enable the trusted
+publisher before running the workflow. If a run publishes one crate and fails on
+the next one, do not rerun the same version through the workflow; publish the
+missing crate manually or bump every package version before trying again.
 
 ## Assumptions and Limits
 

--- a/crates/s3-unspool-cli/Cargo.toml
+++ b/crates/s3-unspool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool-cli"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/scripts/check-crates-io-publish-target.sh
+++ b/scripts/check-crates-io-publish-target.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "::error title=missing crate names::usage: VERSION=<semver> $0 <crate>..." >&2
+  exit 2
+fi
+
+if [ -z "${VERSION:-}" ]; then
+  echo "::error title=missing version::VERSION must be set to the release version being published." >&2
+  exit 2
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+user_agent="${CRATES_IO_USER_AGENT:-alessandrobologna/s3-unspool release workflow}"
+failed=0
+
+check_crate() {
+  crate="$1"
+
+  crate_status="$(curl -L -sS \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 3 \
+    --retry-delay 2 \
+    --retry-all-errors \
+    -o "$tmp_dir/${crate}.json" \
+    -w "%{http_code}" \
+    -H "User-Agent: ${user_agent}" \
+    "https://crates.io/api/v1/crates/${crate}")"
+  if [ "$crate_status" = "404" ]; then
+    echo "::error title=crate bootstrap required::crates.io crate ${crate} does not exist. Trusted Publishing cannot create new crates; publish this crate once manually with an owner API token, configure Trusted Publishing for this workflow, then release a new version." >&2
+    failed=1
+    return
+  fi
+  if [ "$crate_status" != "200" ]; then
+    cat "$tmp_dir/${crate}.json" >&2
+    echo "::error title=unexpected crates.io response::got HTTP ${crate_status} while checking crate ${crate}." >&2
+    failed=1
+    return
+  fi
+
+  version_status="$(curl -L -sS \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 3 \
+    --retry-delay 2 \
+    --retry-all-errors \
+    -o "$tmp_dir/${crate}-${VERSION}.json" \
+    -w "%{http_code}" \
+    -H "User-Agent: ${user_agent}" \
+    "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
+  if [ "$version_status" = "200" ]; then
+    echo "::error title=crate version already published::crate ${crate} ${VERSION} is already published; bump the workspace version before rerunning the publish workflow." >&2
+    failed=1
+    return
+  fi
+  if [ "$version_status" != "404" ]; then
+    cat "$tmp_dir/${crate}-${VERSION}.json" >&2
+    echo "::error title=unexpected crates.io response::got HTTP ${version_status} while checking ${crate} ${VERSION}." >&2
+    failed=1
+  fi
+}
+
+for crate in "$@"; do
+  check_crate "$crate"
+done
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- bump `s3-unspool` and `s3-unspool-cli` from `0.1.0-beta.3` to `0.1.0-beta.4`
- add a shared crates.io publish-target preflight script so missing crate bootstrap or already-published versions fail before any upload
- invoke that script both before release artifact builds and immediately before trusted publishing
- document the manual bootstrap/partial-publish recovery path

## Root Cause

The first trusted publishing run partially published `s3-unspool 0.1.0-beta.3`, then failed when publishing `s3-unspool-cli` because crates.io Trusted Publishing cannot create a new crate name. The CLI crate has now been manually bootstrapped, so the next workflow run needs a fresh version.

## Workflow Semantics

- `workflow_dispatch` still requires `refs/heads/main` before publishing.
- The publish job still requires the `release` environment and keeps `id-token: write` scoped to crates.io trusted publishing.
- Both crate names are now required to exist before the workflow can build or upload release artifacts.
- Both target versions must be absent before publish begins; beta.4 currently returns `404` for both crates.
- The shared script path is included in both workflow path filters so changes to the release preflight trigger PR checks.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); YAML.load_file(ARGV.fetch(1)); puts "yaml ok"' .github/workflows/publish-s3-unspool.yml .github/workflows/s3-unspool-ci.yml`
- `actionlint -shellcheck "$(command -v shellcheck)" .github/workflows/publish-s3-unspool.yml .github/workflows/s3-unspool-ci.yml`
- `bash -n scripts/check-crates-io-publish-target.sh`
- `shellcheck scripts/check-crates-io-publish-target.sh`
- `VERSION=0.1.0-beta.4 scripts/check-crates-io-publish-target.sh s3-unspool s3-unspool-cli`
- live crates.io probe: both crate names return `200`, both `0.1.0-beta.4` versions return `404`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo test -p s3-unspool`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo test -p s3-unspool-cli`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo clippy -p s3-unspool --all-targets -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo clippy -p s3-unspool-cli --all-targets -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 RUSTDOCFLAGS='-D warnings' cargo doc -p s3-unspool --no-deps`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo publish -p s3-unspool --dry-run --allow-dirty`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo package -p s3-unspool-cli --list --allow-dirty`

## Release Notes

Before dispatching the workflow for beta.4, configure Trusted Publishing for both crates with repository `alessandrobologna/s3-unspool`, workflow `publish-s3-unspool.yml`, and environment `release`.