### PR TITLE
release: fix cargo-binstall archive layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3-unspool"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "s3-unspool-cli"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ignore = "0.4.25"
 lambda_runtime = "1.1.3"
 libc = "0.2.186"
 md5 = { package = "md-5", version = "0.11.0" }
-s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.4", default-features = false }
+s3-unspool = { path = "crates/s3-unspool", version = "=0.1.0-beta.5", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 terminal_size = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,13 @@ Install the CLI with `cargo-binstall` when prebuilt GitHub Release artifacts are
 available:
 
 ```sh
-cargo binstall s3-unspool-cli --version 0.1.0-beta.4
+cargo binstall s3-unspool-cli --version 0.1.0-beta.5
 ```
 
 The CLI crate name is `s3-unspool-cli`, but the installed command is
-`s3-unspool`.
+`s3-unspool`. Because current releases are prereleases, include the explicit
+version; unqualified `cargo binstall s3-unspool-cli` resolves stable versions
+only.
 
 ## Quick Start
 
@@ -399,7 +401,7 @@ The CLI runs the same zip and unzip flows from a terminal. Install the
 pre-release binary with `cargo-binstall`, or build it from a checkout:
 
 ```sh
-cargo binstall s3-unspool-cli --version 0.1.0-beta.4
+cargo binstall s3-unspool-cli --version 0.1.0-beta.5
 ```
 
 ```sh
@@ -590,7 +592,7 @@ identifiers such as `0.1.0-alpha.1`, `0.1.0-beta.1`, or `0.1.0-rc.1`.
 Consumers opt into a pre-release explicitly:
 
 ```sh
-cargo add s3-unspool@0.1.0-beta.4
+cargo add s3-unspool@0.1.0-beta.5
 ```
 
 Releases are published by the manual `Publish s3-unspool` GitHub Actions

--- a/crates/s3-unspool-cli/Cargo.toml
+++ b/crates/s3-unspool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool-cli"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -18,11 +18,12 @@ path = "src/main.rs"
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.xz"
 pkg-fmt = "txz"
-bin-dir = "{ bin }{ binary-ext }"
+bin-dir = "{ name }-{ target }/{ bin }{ binary-ext }"
 
 [package.metadata.binstall.overrides.'cfg(windows)']
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
 pkg-fmt = "zip"
+bin-dir = "{ bin }{ binary-ext }"
 
 [features]
 default = ["zstd"]

--- a/crates/s3-unspool/Cargo.toml
+++ b/crates/s3-unspool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-unspool"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

- bump `s3-unspool` and `s3-unspool-cli` from `0.1.0-beta.4` to `0.1.0-beta.5`
- fix `s3-unspool-cli` cargo-binstall metadata for Unix/macOS tar archives by pointing `bin-dir` at the cargo-dist top-level archive directory
- keep the Windows zip override at archive root
- document that prerelease installs need an explicit version because unqualified binstall resolves stable versions only

## Root Cause

`cargo binstall s3-unspool-cli` fails because the crate only has prerelease versions, so the implicit `*` requirement does not match anything. With an explicit prerelease version, beta.4 then falls back to source because the released tar archives contain `s3-unspool-cli-<target>/s3-unspool`, while the published binstall metadata says the binary is at archive root. The beta.4 crate metadata is immutable, so the durable fix needs a new beta.

## Validation

- live crates.io probe: both crate names return `200`, both `0.1.0-beta.5` versions return `404`
- inspected `v0.1.0-beta.4` GitHub Release archives: macOS/Linux tar archives include a top-level `s3-unspool-cli-<target>/` directory; Windows zip stores `s3-unspool.exe` at archive root
- `cargo binstall s3-unspool-cli@0.1.0-beta.4 --dry-run -y --bin-dir '{ name }-{ target }/{ bin }{ binary-ext }'`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo test -p s3-unspool-cli`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo package -p s3-unspool-cli --list --allow-dirty`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo publish -p s3-unspool --dry-run --allow-dirty`
- `git diff --check`

## Current beta.4 workaround

Until beta.5 is published, install beta.4 with:

```sh
cargo binstall s3-unspool-cli@0.1.0-beta.4 --bin-dir '{ name }-{ target }/{ bin }{ binary-ext }'
```