### PR TITLE
fix: silence windows dead-code warning

### DIFF
--- a/crates/s3-unspool/src/extract.rs
+++ b/crates/s3-unspool/src/extract.rs
@@ -2949,6 +2949,7 @@ fn windows_path(path: &Path) -> Vec<u16> {
     path.as_os_str().encode_wide().chain(Some(0)).collect()
 }
 
+#[cfg(unix)]
 fn alternate_case_name(name: &std::ffi::OsStr) -> Option<String> {
     let name = name.to_str()?;
     let mut changed = false;


### PR DESCRIPTION
## Summary

- compile `alternate_case_name` only on Unix, matching its only caller
- remove the Windows build warning for the unused helper without changing runtime behavior

## Root Cause

`infer_case_insensitive_paths_from_existing_names` has a Unix implementation that uses `alternate_case_name`, plus a non-Unix fallback that returns `Ok(None)`. The helper itself was not `#[cfg(unix)]`, so Windows compiled the private helper without any caller and emitted `dead_code` during the Windows artifact build.

## Validation

- `RUSTUP_TOOLCHAIN=1.95.0 cargo fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo check -p s3-unspool`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo clippy -p s3-unspool --all-targets -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo test -p s3-unspool`
- `git diff --check`

## Note

I also tried `RUSTUP_TOOLCHAIN=1.95.0 cargo check -p s3-unspool --target x86_64-pc-windows-msvc` locally, but this macOS host cannot complete the dependency C builds for `ring`/`zstd-sys` without Windows/MSVC C headers. The GitHub Windows runner should be the target-specific verification for this one-line cfg fix.