### PR TITLE
release: add changelog-backed release notes

### DIFF
--- a/.github/workflows/publish-s3-unspool.yml
+++ b/.github/workflows/publish-s3-unspool.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - ".github/workflows/publish-s3-unspool.yml"
+      - "CHANGELOG.md"
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/s3-unspool/**"
@@ -13,6 +14,7 @@ on:
       - "dist-workspace.toml"
       - "rust-toolchain.toml"
       - "scripts/check-crates-io-publish-target.sh"
+      - "scripts/render-release-notes.sh"
   workflow_dispatch:
 
 permissions: {}
@@ -530,6 +532,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
           submodules: recursive
 
@@ -550,15 +553,16 @@ jobs:
           ANNOUNCEMENT_BODY: "${{ fromJson(needs.host.outputs.val).announcement_github_body }}"
           RELEASE_COMMIT: ${{ github.sha }}
           TAG: ${{ needs.plan.outputs.tag }}
+          OUTPUT_PATH: ${{ runner.temp }}/notes.md
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s' "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.md"
+          scripts/render-release-notes.sh
           args=(
             "$TAG"
             --target "$RELEASE_COMMIT"
             --title "$ANNOUNCEMENT_TITLE"
-            --notes-file "$RUNNER_TEMP/notes.md"
+            --notes-file "$OUTPUT_PATH"
           )
           if [ -n "$PRERELEASE_FLAG" ]; then
             args+=("$PRERELEASE_FLAG")

--- a/.github/workflows/s3-unspool-ci.yml
+++ b/.github/workflows/s3-unspool-ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/publish-s3-unspool.yml"
       - ".github/workflows/s3-unspool-ci.yml"
+      - "CHANGELOG.md"
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/s3-unspool/**"
@@ -14,6 +15,7 @@ on:
       - "dist-workspace.toml"
       - "rust-toolchain.toml"
       - "scripts/check-crates-io-publish-target.sh"
+      - "scripts/render-release-notes.sh"
 
 permissions: {}
 
@@ -43,6 +45,9 @@ jobs:
             --component rustfmt
           rustup default "$RUSTUP_TOOLCHAIN"
           rustc --version
+
+      - name: Check release scripts
+        run: bash -n scripts/check-crates-io-publish-target.sh scripts/render-release-notes.sh
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## Unreleased
+
+### Changed
+
+- Release notes now include the exact `cargo binstall` command and a first-parent
+  commit list for every GitHub Release.
+
+## 0.1.0-beta.5 - 2026-05-03
+
+### Fixed
+
+- Fixed `cargo-binstall` metadata so Unix and macOS release archives resolve the
+  `s3-unspool` binary inside the `cargo-dist` top-level archive directory.
+- Kept the Windows `cargo-binstall` metadata pointed at the zip archive root.
+
+### Documentation
+
+- Documented that prerelease CLI installs must include an explicit version.
+
+## 0.1.0-beta.4 - 2026-05-03
+
+### Fixed
+
+- Added crates.io publish-target preflights so missing crate bootstrap or
+  already-published versions fail before release artifacts are built or uploaded.
+- Documented the manual Trusted Publishing bootstrap and partial-publish recovery
+  path.

--- a/scripts/render-release-notes.sh
+++ b/scripts/render-release-notes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "::error title=missing environment::${name} must be set." >&2
+    exit 2
+  fi
+}
+
+require_env ANNOUNCEMENT_BODY
+require_env RELEASE_COMMIT
+require_env TAG
+
+export TAG
+
+output_path="${OUTPUT_PATH:-${RUNNER_TEMP:-/tmp}/notes.md}"
+version="${TAG#v}"
+repository="${GITHUB_REPOSITORY:-alessandrobologna/s3-unspool}"
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+
+git fetch --tags --force origin >/dev/null
+
+previous_tag="$(
+  gh release list \
+    --limit 50 \
+    --json tagName,isDraft \
+    --jq '[.[] | select(.isDraft == false and .tagName != env.TAG)][0].tagName // ""'
+)"
+
+render_commits() {
+  if [ -n "$previous_tag" ]; then
+    echo "Since ${previous_tag}:"
+    echo
+    commits="$(git log --first-parent --reverse --pretty=format:'- %s (%h)' "${previous_tag}..${RELEASE_COMMIT}")"
+    if [ -n "$commits" ]; then
+      printf '%s\n' "$commits"
+    else
+      echo "- No first-parent commits since ${previous_tag}."
+    fi
+    echo
+    echo "[Full diff](${server_url}/${repository}/compare/${previous_tag}...${TAG})"
+    return
+  fi
+
+  echo "Initial release commits:"
+  echo
+  git log --first-parent --reverse --pretty=format:'- %s (%h)' "$RELEASE_COMMIT"
+  echo
+}
+
+{
+  echo "## Install CLI"
+  echo
+  echo '```sh'
+  echo "cargo binstall s3-unspool-cli@${version}"
+  echo '```'
+  echo
+  printf '%s\n\n' "$ANNOUNCEMENT_BODY"
+  echo "## Commits"
+  echo
+  render_commits
+} > "$output_path"


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with the current beta release history and an `Unreleased` section.
- Render GitHub Release notes through `scripts/render-release-notes.sh` so every release starts with `cargo binstall s3-unspool-cli@<version>`, then includes cargo-dist's changelog/download body and a first-parent commit list with a compare link.
- Include the changelog and release-note script in release-related path filters, and add CI syntax checking for release scripts.

## Workflow review
- Trigger path: PR validation remains `pull_request` to `main` with path filters; publishing remains manual `workflow_dispatch` from `main` only.
- Checkout/ref/token path: the announce job checks out the workflow commit with full history for first-parent logs, keeps `persist-credentials: false`, and uses `GH_TOKEN` only for `gh release list` plus the existing `gh release create` call.
- Permission path: permissions remain `{}` by default; the only release mutation job is still `announce` with `contents: write`, and crates.io publishing still uses OIDC only in the `publish` job.
- Version/tag path: the existing duplicate tag/release preflight remains in `plan`; this PR does not add any new ref mutation or cleanup behavior.
- Shell path: the new script runs under `set -euo pipefail`, fails fast on missing required env, fetches tags for compare links, and excludes the current tag when finding the previous release.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }; puts "yaml ok"' .github/workflows/publish-s3-unspool.yml .github/workflows/s3-unspool-ci.yml`
- `bash -n scripts/check-crates-io-publish-target.sh scripts/render-release-notes.sh`
- `shellcheck scripts/check-crates-io-publish-target.sh scripts/render-release-notes.sh`
- `actionlint -shellcheck "$(command -v shellcheck)" .github/workflows/publish-s3-unspool.yml .github/workflows/s3-unspool-ci.yml`
- `git diff --check`
- `dist plan --output-format=json`
- local render smoke test using `v0.1.0-beta.5`, which produced the `cargo binstall s3-unspool-cli@0.1.0-beta.5` command, changelog-backed cargo-dist body, and commits since `v0.1.0-beta.4`.
